### PR TITLE
Configure guestlib with config file

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,3 +30,6 @@
 	path = third_party/protobuf
 	url = https://github.com/google/protobuf.git
 	branch = v3.6.1
+[submodule "third_party/libconfig"]
+	path = third_party/libconfig
+	url = https://github.com/hyperrealm/libconfig.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,16 @@ ExternalProject_Add(flatbuffers
   DEPENDS protobuf grpc
 )
 
+# Build config parser library
+
+ExternalProject_Add(libconfig
+  PREFIX libconfig
+  SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/third_party/libconfig"
+  CMAKE_CACHE_ARGS
+        -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
+        -DCMAKE_INSTALL_PREFIX:PATH=${EXTERNAL_BINARY_DIR}/libconfig
+)
+
 ###### Compile proto files ######
 
 ExternalProject_Add(ava-proto
@@ -188,6 +198,7 @@ ExternalProject_Add(ava-spec
         ${_CMAKE_ARGS_OPENSSL_ROOT_DIR}
         -DgRPC_DIR:PATH=${EXTERNAL_BINARY_DIR}/grpc/lib/cmake/grpc
         -DFlatbuffers_DIR:PATH=${EXTERNAL_BINARY_DIR}/flatbuffers/lib/cmake/flatbuffers
+        -Dlibconfig++_DIR:PATH=${EXTERNAL_BINARY_DIR}/libconfig/lib/cmake/libconfig
   BUILD_ALWAYS ON
-  DEPENDS protobuf grpc flatbuffers
+  DEPENDS protobuf grpc flatbuffers libconfig
 )

--- a/cava/nightwatch/generator/c/cmakelists.py
+++ b/cava/nightwatch/generator/c/cmakelists.py
@@ -48,6 +48,7 @@ set(_GRPC_GRPCPP gRPC::grpc++)
 
 find_package(libconfig++ CONFIG REQUIRED)
 message(STATUS "Using libconfig++ ${{libconfig++_VERSION}}")
+include_directories(${{libconfig++_DIR}}/../../../include)
 set(_LIBCONFIG_CONFIG++ libconfig::config++)
 
 ###### Set generated files ######
@@ -97,6 +98,7 @@ target_link_libraries(worker
 
 add_library(guestlib SHARED
   ${{CMAKE_SOURCE_DIR}}/../../guestlib/src/init.cpp
+  ${{CMAKE_SOURCE_DIR}}/../../guestlib/src/guest_config.cpp
   ${{CMAKE_SOURCE_DIR}}/../../common/cmd_channel_shm.c
   {api.c_library_spelling}
   ${{CMAKE_SOURCE_DIR}}/../../common/cmd_channel.c

--- a/cava/nightwatch/generator/c/cmakelists.py
+++ b/cava/nightwatch/generator/c/cmakelists.py
@@ -46,6 +46,10 @@ message(STATUS "Using gRPC ${{gRPC_VERSION}}")
 set(_REFLECTION gRPC::grpc++_reflection)
 set(_GRPC_GRPCPP gRPC::grpc++)
 
+find_package(libconfig++ CONFIG REQUIRED)
+message(STATUS "Using libconfig++ ${{libconfig++_VERSION}}")
+set(_LIBCONFIG_CONFIG++ libconfig::config++)
+
 ###### Set generated files ######
 
 set(manager_service_grpc_srcs  "${{CMAKE_BINARY_DIR}}/../../proto/manager_service.grpc.fb.cc")
@@ -117,6 +121,7 @@ target_link_libraries(guestlib
   ${{_FLATBUFFERS}}
   ${{GLIB2_LIBRARIES}}
   Threads::Threads
+  ${{_LIBCONFIG_CONFIG++}}
 )
     """.strip()
     return "CMakeLists.txt", cmakelists

--- a/common/cmd_channel_socket_tcp.cpp
+++ b/common/cmd_channel_socket_tcp.cpp
@@ -52,10 +52,11 @@ struct command_channel* command_channel_socket_tcp_new(int worker_port, int is_g
     if (is_guest) {
         chan->vm_id = nw_global_vm_id = 1;
 
-        auto channel = grpc::CreateChannel(guest_config->manager_address_, grpc::InsecureChannelCredentials());
+        auto channel = grpc::CreateChannel(guestconfig::config->manager_address_, grpc::InsecureChannelCredentials());
         auto client  = std::make_unique<ManagerServiceClient>(channel);
         std::vector<uint64_t> gpu_mem;
-        std::vector<std::string> worker_address = client->AssignWorker(1, 0, gpu_mem);
+        std::vector<std::string> worker_address =
+            client->AssignWorker(1, guestconfig::config->gpu_memory_.size(), guestconfig::config->gpu_memory_);
         assert(!worker_address.empty() && "No API server is assigned");
 
         char worker_name[128];
@@ -77,8 +78,9 @@ struct command_channel* command_channel_socket_tcp_new(int worker_port, int is_g
         address.sin_family = AF_INET;
         address.sin_addr = *(struct in_addr *)worker_server_info->h_addr;
         address.sin_port = htons(worker_port);
-        fprintf(stderr, "Connect target worker (%s) at %s:%d\n",
-                worker_address[0].c_str(), inet_ntoa(address.sin_addr), worker_port);
+        std::cerr <<  "Connect target API server (" << worker_address[0]
+                  << ") at " << inet_ntoa(address.sin_addr)
+                  << ":" << worker_port << std::endl;
         connect(chan->sock_fd, (struct sockaddr *)&address, sizeof(address));
     }
     else {

--- a/common/socket.cpp
+++ b/common/socket.cpp
@@ -244,8 +244,10 @@ void parseServerAddress(const char* full_address, struct hostent** info,
       *port = atoi(full_address);
   }
   else {
-    if (ip)
+    if (ip) {
       strncpy(ip, full_address, port_s - full_address);
+      ip[port_s - full_address] = '\0';
+    }
     if (port)
       *port = atoi(port_s + 1);
   }

--- a/config/README.md
+++ b/config/README.md
@@ -14,4 +14,4 @@ Run `setup.sh` to install an example configuration.
 | manager_address  | "0.0.0.0:3334" | "0.0.0.0:3334" | AvA manager's address                   |
 | instance_type    | "ava.xlarge"   | Ignored        | Service instance type                   |
 | gpu_count        | 2              | Ignored        | Number of requested GPU, currently represented by `gpu_memory.size()` |
-| gpu_memory       | [1024,512]     | []             | Requested GPU memory sizes, in MB       |
+| gpu_memory       | [1024L,512LL]  | []             | Requested GPU memory sizes, in MB       |

--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,17 @@
+Configuration Files
+===================
+
+Configuration files are replacing environment variables for AvA's settings.
+Guestlib reads `/etc/ava/guest.conf` for user-defined configurations.
+
+Run `setup.sh` to install an example configuration.
+
+## Guest configuration
+
+| Name             | Example        | Default        | Explanation                             |
+|------------------|----------------|----------------|-----------------------------------------|
+| channel          | "TCP"          | "TCP"          | Transport channel (TCP\|SHM\|VSOCK)     |
+| manager_address  | "0.0.0.0:3334" | "0.0.0.0:3334" | AvA manager's address                   |
+| instance_type    | "ava.xlarge"   | Ignored        | Service instance type                   |
+| gpu_count        | 2              | Ignored        | Number of requested GPU, currently represented by `gpu_memory.size()` |
+| gpu_memory       | [1024,512]     | []             | Requested GPU memory sizes, in MB       |

--- a/config/guest.conf
+++ b/config/guest.conf
@@ -2,4 +2,4 @@
 # manager_address = "0.0.0.0:3334";
 # instance_type = "ava.xlarge";
 # gpu_count = 1;
-# gpu_memory = [1024]; # in MB
+# gpu_memory = [1024L]; # in MB

--- a/config/guest.conf
+++ b/config/guest.conf
@@ -1,0 +1,5 @@
+# channel = "TCP";
+# manager_address = "0.0.0.0:3334";
+# instance_type = "ava.xlarge";
+# gpu_count = 1;
+# gpu_memory = [1024]; # in MB

--- a/config/guest.conf.example
+++ b/config/guest.conf.example
@@ -1,3 +1,3 @@
 channel = "TCP";
 manager_address = "0.0.0.0:3334";
-gpu_memory = [1024];
+gpu_memory = [1024L];

--- a/config/guest.conf.example
+++ b/config/guest.conf.example
@@ -1,0 +1,3 @@
+channel = "TCP";
+manager_address = "0.0.0.0:3334";
+gpu_memory = [1024];

--- a/config/setup.sh
+++ b/config/setup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+dir_name=$(dirname $(realpath $0))
+
+if [[ $EUID -ne 0 ]]; then
+    echo "Require root to run this script"
+    exit 1
+fi
+
+if [[ ! -d /etc/ava ]]; then
+  mkdir /etc/ava
+fi
+
+if [[ ! -f /etc/ava/guest.conf ]]; then
+  cp ${dir_name}/guest.conf.example /etc/ava/guest.conf
+  chmod 644 /etc/ava/guest.conf
+fi

--- a/guestlib/include/guest_config.h
+++ b/guestlib/include/guest_config.h
@@ -1,0 +1,42 @@
+#ifndef AVA_GUESTLIB_GUEST_CONFIG_H_
+#define AVA_GUESTLIB_GUEST_CONFIG_H_
+
+#include <libconfig.h++>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+class GuestConfig {
+public:
+  static std::string const kConfigFilePath;
+  static std::string const kDefaultChannel;
+  static std::string const kDefaultManagerAddress;
+
+  GuestConfig(std::string chan, std::string manager_addr, std::vector<uint64_t>gpu_mem = {}) :
+    channel_(chan), manager_address_(manager_addr), gpu_memory_(gpu_mem) {}
+
+  void print() {
+    std::cerr << "GuestConfig {" << std::endl
+              << "  channel = " << channel_ << std::endl
+              << "  manager_address = " << manager_address_ << std::endl
+              << "  instance_type = (ignored)" << std::endl
+              << "  gpu_count = (ignored)" << std::endl
+              << "  gpu_memory = [";
+    for (auto m : gpu_memory_)
+      std::cerr << m << "M,";
+    std::cerr << "]" << std::endl;
+  }
+
+  std::string channel_;
+  std::string manager_address_;
+  std::string instance_type_; // not used
+  int gpu_count_;             // not used, represented by gpu_memory_.size()
+  std::vector<uint64_t> gpu_memory_;
+};
+
+std::shared_ptr<GuestConfig> readGuestConfig();
+
+extern std::shared_ptr<GuestConfig> guest_config;
+
+#endif  // AVA_GUESTLIB_GUEST_CONFIG_H_

--- a/guestlib/include/guest_config.h
+++ b/guestlib/include/guest_config.h
@@ -7,12 +7,10 @@
 #include <string>
 #include <vector>
 
+namespace guestconfig {
+
 class GuestConfig {
 public:
-  static std::string const kConfigFilePath;
-  static std::string const kDefaultChannel;
-  static std::string const kDefaultManagerAddress;
-
   GuestConfig(std::string chan, std::string manager_addr, std::vector<uint64_t>gpu_mem = {}) :
     channel_(chan), manager_address_(manager_addr), gpu_memory_(gpu_mem) {}
 
@@ -35,8 +33,14 @@ public:
   std::vector<uint64_t> gpu_memory_;
 };
 
+constexpr char kConfigFilePath[]        = "/etc/ava/guest.conf";
+constexpr char kDefaultChannel[]        = "TCP";
+constexpr char kDefaultManagerAddress[] = "0.0.0.0:3334";
+
 std::shared_ptr<GuestConfig> readGuestConfig();
 
-extern std::shared_ptr<GuestConfig> guest_config;
+extern std::shared_ptr<GuestConfig> config;
+
+}  // namespace guestconfig
 
 #endif  // AVA_GUESTLIB_GUEST_CONFIG_H_

--- a/guestlib/src/guest_config.cpp
+++ b/guestlib/src/guest_config.cpp
@@ -1,0 +1,52 @@
+#include <iomanip>
+#include "guest_config.h"
+
+std::string const GuestConfig::kConfigFilePath = "/etc/ava/guest.conf";
+std::string const GuestConfig::kDefaultChannel = "TCP";
+std::string const GuestConfig::kDefaultManagerAddress = "0.0.0.0:3334";
+
+std::shared_ptr<GuestConfig> readGuestConfig() {
+  libconfig::Config cfg;
+
+  try {
+    cfg.readFile(GuestConfig::kConfigFilePath);
+  }
+  catch(const libconfig::FileIOException& fioex) {
+    std::cerr << "I/O error when reading " << GuestConfig::kConfigFilePath << std::endl;
+    return nullptr;
+  }
+  catch(const libconfig::ParseException& pex) {
+    std::cerr << "Parse error at " << pex.getFile() << ":" << pex.getLine()
+              << " - " << pex.getError() << std::endl;
+    return nullptr;
+  }
+
+  const libconfig::Setting& root = cfg.getRoot();
+  std::string channel = GuestConfig::kDefaultChannel;
+  std::string manager_address = GuestConfig::kDefaultManagerAddress;
+  std::vector<uint64_t> gpu_memory;
+
+  try {
+    std::string chan;
+    root.lookupValue("channel", chan);
+    channel = chan;
+  }
+  catch(const libconfig::SettingNotFoundException& nfex) {
+  }
+  try {
+    std::string addr;
+    root.lookupValue("manager_address", addr);
+    manager_address = addr;
+  }
+  catch(const libconfig::SettingNotFoundException& nfex) {
+  }
+  try {
+    const libconfig::Setting& gpu_mem_settings = root.lookup("gpu_memory");
+    for (int i = 0; i < gpu_mem_settings.getLength(); ++i)
+      gpu_memory.push_back(gpu_mem_settings[i]);
+  }
+  catch(const libconfig::SettingNotFoundException& nfex) {
+  }
+
+  return std::make_shared<GuestConfig>(channel, manager_address, gpu_memory);
+}

--- a/guestlib/src/init.cpp
+++ b/guestlib/src/init.cpp
@@ -18,7 +18,6 @@
 #include "common/cmd_channel_impl.h"
 
 struct command_channel *chan;
-std::shared_ptr<GuestConfig> guest_config;
 
 struct param_block_info nw_global_pb_info = {0, 0};
 extern int nw_global_vm_id;
@@ -32,9 +31,11 @@ EXPORTED_WEAKLY void nw_init_guestlib(intptr_t api_id)
 {
     std::ios_base::Init();
 
-    guest_config = readGuestConfig();
+    guestconfig::config = guestconfig::readGuestConfig();
+    if (guestconfig::config == nullptr)
+      exit(EXIT_FAILURE);
 #ifdef DEBUG
-    guest_config->print();
+    guestconfig::config->print();
 #endif
 
 #ifdef AVA_PRINT_TIMESTAMP
@@ -43,18 +44,18 @@ EXPORTED_WEAKLY void nw_init_guestlib(intptr_t api_id)
 #endif
 
     /* Create connection to worker and start command handler thread */
-    if (guest_config->channel_ == "TCP") {
+    if (guestconfig::config->channel_ == "TCP") {
         chan = command_channel_socket_tcp_new(0, 1);
     }
-    else if (guest_config->channel_ == "SHM") {
+    else if (guestconfig::config->channel_ == "SHM") {
         chan = command_channel_shm_new();
     }
-    else if (guest_config->channel_ == "VSOCK") {
+    else if (guestconfig::config->channel_ == "VSOCK") {
         chan = command_channel_socket_new();
     }
     else {
         std::cerr << "Unsupported channel specified in "
-                  << GuestConfig::kConfigFilePath
+                  << guestconfig::kConfigFilePath
                   << ", expect channel = [\"TCP\" | \"SHM\" | \"VSOCK\"]" << std::endl;
         exit(0);
     }


### PR DESCRIPTION
This PR replaces the configuration environment variables for guestlib with a config file at `/etc/ava/guest.conf`.
Check `conf/README.md` for more details.