### PR TITLE
Retry connection to API server for TCP channel

### DIFF
--- a/common/cmd_channel_socket_tcp.cpp
+++ b/common/cmd_channel_socket_tcp.cpp
@@ -54,9 +54,11 @@ struct command_channel* command_channel_socket_tcp_new(int worker_port, int is_g
 
         auto channel = grpc::CreateChannel(guestconfig::config->manager_address_, grpc::InsecureChannelCredentials());
         auto client  = std::make_unique<ManagerServiceClient>(channel);
-        std::vector<uint64_t> gpu_mem;
+        std::vector<uint64_t> gpu_mem_in_bytes;
+        for (auto m : guestconfig::config->gpu_memory_)
+          gpu_mem_in_bytes.push_back(m << 20);
         std::vector<std::string> worker_address =
-            client->AssignWorker(1, guestconfig::config->gpu_memory_.size(), guestconfig::config->gpu_memory_);
+            client->AssignWorker(0, guestconfig::config->gpu_memory_.size(), gpu_mem_in_bytes);
         assert(!worker_address.empty() && "No API server is assigned");
 
         char worker_name[128];

--- a/config/README.md
+++ b/config/README.md
@@ -11,6 +11,7 @@ Run `setup.sh` to install an example configuration.
 | Name             | Example        | Default        | Explanation                             |
 |------------------|----------------|----------------|-----------------------------------------|
 | channel          | "TCP"          | "TCP"          | Transport channel (TCP\|SHM\|VSOCK)     |
+| connect_timeout  | 5000L          | 5000L          | Timeout for API server connection, in milliseconds |
 | manager_address  | "0.0.0.0:3334" | "0.0.0.0:3334" | AvA manager's address                   |
 | instance_type    | "ava.xlarge"   | Ignored        | Service instance type                   |
 | gpu_count        | 2              | Ignored        | Number of requested GPU, currently represented by `gpu_memory.size()` |

--- a/config/guest.conf
+++ b/config/guest.conf
@@ -1,4 +1,5 @@
 # channel = "TCP";
+# connect_timeout = 5000L; # in milliseconds
 # manager_address = "0.0.0.0:3334";
 # instance_type = "ava.xlarge";
 # gpu_count = 1;

--- a/config/guest.conf.example
+++ b/config/guest.conf.example
@@ -1,3 +1,4 @@
 channel = "TCP";
+connect_timeout = 5000L;
 manager_address = "0.0.0.0:3334";
 gpu_memory = [1024L];

--- a/guestlib/include/guest_config.h
+++ b/guestlib/include/guest_config.h
@@ -9,14 +9,23 @@
 
 namespace guestconfig {
 
+constexpr char kConfigFilePath[]          = "/etc/ava/guest.conf";
+constexpr char kDefaultChannel[]          = "TCP";
+constexpr uint64_t kDefaultConnectTimeout = 5000;
+constexpr char kDefaultManagerAddress[]   = "0.0.0.0:3334";
+
 class GuestConfig {
 public:
-  GuestConfig(std::string chan, std::string manager_addr, std::vector<uint64_t>gpu_mem = {}) :
+  GuestConfig(std::string chan,
+              std::string manager_addr,
+              uint64_t connect_timeout = kDefaultConnectTimeout,
+              std::vector<uint64_t>gpu_mem = {}) :
     channel_(chan), manager_address_(manager_addr), gpu_memory_(gpu_mem) {}
 
   void print() {
     std::cerr << "GuestConfig {" << std::endl
               << "  channel = " << channel_ << std::endl
+              << "  connect_timeout = " << connect_timeout_ << std::endl
               << "  manager_address = " << manager_address_ << std::endl
               << "  instance_type = (ignored)" << std::endl
               << "  gpu_count = (ignored)" << std::endl
@@ -27,15 +36,12 @@ public:
   }
 
   std::string channel_;
+  uint64_t connect_timeout_;
   std::string manager_address_;
   std::string instance_type_; // not used
   int gpu_count_;             // not used, represented by gpu_memory_.size()
   std::vector<uint64_t> gpu_memory_;
 };
-
-constexpr char kConfigFilePath[]        = "/etc/ava/guest.conf";
-constexpr char kDefaultChannel[]        = "TCP";
-constexpr char kDefaultManagerAddress[] = "0.0.0.0:3334";
 
 std::shared_ptr<GuestConfig> readGuestConfig();
 

--- a/guestlib/src/guest_config.cpp
+++ b/guestlib/src/guest_config.cpp
@@ -23,11 +23,17 @@ std::shared_ptr<GuestConfig> readGuestConfig() {
 
   const libconfig::Setting& root = cfg.getRoot();
   std::string channel = guestconfig::kDefaultChannel;
+  unsigned long long connect_timeout = guestconfig::kDefaultConnectTimeout;
   std::string manager_address = guestconfig::kDefaultManagerAddress;
   std::vector<uint64_t> gpu_memory;
 
   try {
     root.lookupValue("channel", channel);
+  }
+  catch(const libconfig::SettingNotFoundException& nfex) {
+  }
+  try {
+    root.lookupValue("connect_timeout", connect_timeout);
   }
   catch(const libconfig::SettingNotFoundException& nfex) {
   }
@@ -48,7 +54,7 @@ std::shared_ptr<GuestConfig> readGuestConfig() {
     return nullptr;
   }
 
-  return std::make_shared<GuestConfig>(channel, manager_address, gpu_memory);
+  return std::make_shared<GuestConfig>(channel, manager_address, connect_timeout, gpu_memory);
 }
 
 }  // namespace guestconfig


### PR DESCRIPTION
The guestlib retries to connect the API server until timeout.
This PR only corrects the TCP channel, while the other channels should follow this change.