### PR TITLE
Patch gRPC to avoid gettid build failure

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,6 +26,7 @@
 	path = third_party/grpc
 	url = https://github.com/grpc/grpc.git
 	branch = v1.15.1
+  ignore = dirty
 [submodule "third_party/protobuf"]
 	path = third_party/protobuf
 	url = https://github.com/google/protobuf.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,9 @@ include(ExternalProject)
 
 set(EXTERNAL_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/third_party)
 
+set(_GRPC_DEPEND_LIST c-ares zlib absl)
+set(_FLATBUFFERS_DEPEND_LIST "")
+
 # Builds absl project from the git submodule.
 ExternalProject_Add(absl
   PREFIX absl
@@ -65,18 +68,26 @@ ExternalProject_Add(c-ares
         -DCMAKE_INSTALL_PREFIX:PATH=${EXTERNAL_BINARY_DIR}/c-ares
 )
 
-# Builds protobuf project from the git submodule.
-ExternalProject_Add(protobuf
-  PREFIX protobuf
-  SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/third_party/protobuf"
-  SOURCE_SUBDIR "cmake"
-  CMAKE_CACHE_ARGS
-        -Dprotobuf_BUILD_TESTS:BOOL=OFF
-        -Dprotobuf_WITH_ZLIB:BOOL=OFF
-        -Dprotobuf_MSVC_STATIC_RUNTIME:BOOL=OFF
-        -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
-        -DCMAKE_INSTALL_PREFIX:PATH=${EXTERNAL_BINARY_DIR}/protobuf
-)
+find_package(Protobuf 3.6.1 CONFIG QUIET)
+if (NOT ${Protobuf_FOUND})
+  # Builds protobuf project from the git submodule.
+  ExternalProject_Add(protobuf
+    PREFIX protobuf
+    SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/third_party/protobuf"
+    SOURCE_SUBDIR "cmake"
+    CMAKE_CACHE_ARGS
+          -Dprotobuf_BUILD_TESTS:BOOL=OFF
+          -Dprotobuf_WITH_ZLIB:BOOL=OFF
+          -Dprotobuf_MSVC_STATIC_RUNTIME:BOOL=OFF
+          -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
+          -DCMAKE_INSTALL_PREFIX:PATH=${EXTERNAL_BINARY_DIR}/protobuf
+  )
+  set(_Protobuf_DIR "${EXTERNAL_BINARY_DIR}/protobuf/lib/cmake/protobuf")
+  list(APPEND _GRPC_DEPEND_LIST protobuf)
+  list(APPEND _FLATBUFFERS_DEPEND_LIST protobuf)
+else()
+  set(_Protobuf_DIR ${Protobuf_DIR})
+endif()
 
 # Builds zlib project from the git submodule.
 ExternalProject_Add(zlib
@@ -87,49 +98,54 @@ ExternalProject_Add(zlib
         -DCMAKE_INSTALL_PREFIX:PATH=${EXTERNAL_BINARY_DIR}/zlib
 )
 
-set(_FINDPACKAGE_PROTOBUF_CONFIG_DIR "${EXTERNAL_BINARY_DIR}/protobuf/lib/cmake/protobuf")
-
 # if OPENSSL_ROOT_DIR is set, propagate that hint path to the external projects with OpenSSL dependency.
 set(_CMAKE_ARGS_OPENSSL_ROOT_DIR "")
 if (OPENSSL_ROOT_DIR)
   set(_CMAKE_ARGS_OPENSSL_ROOT_DIR "-DOPENSSL_ROOT_DIR:PATH=${OPENSSL_ROOT_DIR}")
 endif()
 
-# Builds gRPC based on locally checked-out sources and set arguments so that all the dependencies
-# are correctly located.
-ExternalProject_Add(grpc
-  PREFIX grpc
-  SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/third_party/grpc"
-  PATCH_COMMAND patch -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/third_party/grpc-gettid.patch
-  CMAKE_CACHE_ARGS
-        -DgRPC_INSTALL:BOOL=ON
-        -DgRPC_BUILD_TESTS:BOOL=OFF
-        -DgRPC_PROTOBUF_PROVIDER:STRING=package
-        -DgRPC_PROTOBUF_PACKAGE_TYPE:STRING=CONFIG
-        -DProtobuf_DIR:PATH=${_FINDPACKAGE_PROTOBUF_CONFIG_DIR}
-        -DgRPC_ZLIB_PROVIDER:STRING=package
-        -DZLIB_DIR:STRING=${EXTERNAL_BINARY_DIR}/zlib
-        -DgRPC_ABSL_PROVIDER:STRING=package
-        -Dabsl_DIR:STRING=${EXTERNAL_BINARY_DIR}/absl/lib/cmake/absl
-        -DgRPC_CARES_PROVIDER:STRING=package
-        -Dc-ares_DIR:PATH=${EXTERNAL_BINARY_DIR}/c-ares/lib/cmake/c-ares
-        -DgRPC_SSL_PROVIDER:STRING=package
-        ${_CMAKE_ARGS_OPENSSL_ROOT_DIR}
-        -DBUILD_SHARED_LIBS:BOOL=ON
-        -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
-        -DCMAKE_INSTALL_PREFIX:PATH=${EXTERNAL_BINARY_DIR}/grpc
-  DEPENDS c-ares protobuf zlib absl
-)
+find_package(gRPC 1.15.1 CONFIG QUIET)
+if (NOT ${gRPC_FOUND})
+  # Builds gRPC based on locally checked-out sources and set arguments so that all the dependencies
+  # are correctly located.
+  ExternalProject_Add(grpc
+    PREFIX grpc
+    SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/third_party/grpc"
+    PATCH_COMMAND patch -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/third_party/grpc-gettid.patch
+    CMAKE_CACHE_ARGS
+          -DgRPC_INSTALL:BOOL=ON
+          -DgRPC_BUILD_TESTS:BOOL=OFF
+          -DgRPC_PROTOBUF_PROVIDER:STRING=package
+          -DgRPC_PROTOBUF_PACKAGE_TYPE:STRING=CONFIG
+          -DProtobuf_DIR:PATH=${_Protobuf_DIR}
+          -DgRPC_ZLIB_PROVIDER:STRING=package
+          -DZLIB_DIR:STRING=${EXTERNAL_BINARY_DIR}/zlib
+          -DgRPC_ABSL_PROVIDER:STRING=package
+          -Dabsl_DIR:STRING=${EXTERNAL_BINARY_DIR}/absl/lib/cmake/absl
+          -DgRPC_CARES_PROVIDER:STRING=package
+          -Dc-ares_DIR:PATH=${EXTERNAL_BINARY_DIR}/c-ares/lib/cmake/c-ares
+          -DgRPC_SSL_PROVIDER:STRING=package
+          ${_CMAKE_ARGS_OPENSSL_ROOT_DIR}
+          -DBUILD_SHARED_LIBS:BOOL=ON
+          -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
+          -DCMAKE_INSTALL_PREFIX:PATH=${EXTERNAL_BINARY_DIR}/grpc
+    DEPENDS ${_GRPC_DEPEND_LIST}
+  )
+  set(_gRPC_DIR ${EXTERNAL_BINARY_DIR}/grpc/lib/cmake/grpc)
+  list(APPEND _FLATBUFFERS_DEPEND_LIST grpc)
+else()
+  set(_gRPC_DIR ${gRPC_DIR})
+endif()
 
 ExternalProject_Add(flatbuffers
   PREFIX flatbuffers
   SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/third_party/flatbuffers"
   CMAKE_CACHE_ARGS
-        -DGRPC_INSTALL_PATH:PATH=${EXTERNAL_BINARY_DIR}/grpc
+        -DGRPC_INSTALL_PATH:PATH=${_gRPC_DIR}/../../..
         -DPROTOBUF_DOWNLOAD_PATH:PATH=${EXTERNAL_BINARY_DIR}/src/protobuf
         -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
         -DCMAKE_INSTALL_PREFIX:PATH=${EXTERNAL_BINARY_DIR}/flatbuffers
-  DEPENDS protobuf grpc
+  DEPENDS ${_FLATBUFFERS_DEPEND_LIST}
 )
 
 # Build config parser library
@@ -150,14 +166,14 @@ ExternalProject_Add(ava-proto
   BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/proto"
   INSTALL_COMMAND ""
   CMAKE_CACHE_ARGS
-        -DProtobuf_DIR:PATH=${_FINDPACKAGE_PROTOBUF_CONFIG_DIR}
+        -DProtobuf_DIR:PATH=${_Protobuf_DIR}
         -Dc-ares_DIR:PATH=${EXTERNAL_BINARY_DIR}/c-ares/lib/cmake/c-ares
         -DZLIB_DIR:STRING=${EXTERNAL_BINARY_DIR}/zlib
         -Dabsl_DIR:STRING=${EXTERNAL_BINARY_DIR}/absl/lib/cmake/absl
         ${_CMAKE_ARGS_OPENSSL_ROOT_DIR}
-        -DgRPC_DIR:PATH=${EXTERNAL_BINARY_DIR}/grpc/lib/cmake/grpc
+        -DgRPC_DIR:PATH=${_gRPC_DIR}
         -DFlatbuffers_DIR:PATH=${EXTERNAL_BINARY_DIR}/flatbuffers/lib/cmake/flatbuffers
-  DEPENDS protobuf grpc flatbuffers
+  DEPENDS flatbuffers
 )
 
 ###### Build AvA manager ######
@@ -174,14 +190,14 @@ ExternalProject_Add(ava-manager
   BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/worker"
   INSTALL_COMMAND ""
   CMAKE_CACHE_ARGS
-        -DProtobuf_DIR:PATH=${_FINDPACKAGE_PROTOBUF_CONFIG_DIR}
+        -DProtobuf_DIR:PATH=${_Protobuf_DIR}
         -Dc-ares_DIR:PATH=${EXTERNAL_BINARY_DIR}/c-ares/lib/cmake/c-ares
         -DZLIB_DIR:STRING=${EXTERNAL_BINARY_DIR}/zlib
         -Dabsl_DIR:STRING=${EXTERNAL_BINARY_DIR}/absl/lib/cmake/absl
         ${_CMAKE_ARGS_OPENSSL_ROOT_DIR}
-        -DgRPC_DIR:PATH=${EXTERNAL_BINARY_DIR}/grpc/lib/cmake/grpc
+        -DgRPC_DIR:PATH=${_gRPC_DIR}
         -DFlatbuffers_DIR:PATH=${EXTERNAL_BINARY_DIR}/flatbuffers/lib/cmake/flatbuffers
-  DEPENDS protobuf grpc flatbuffers
+  DEPENDS flatbuffers
 )
 
 ###### Generate and build remoting stubs ######
@@ -192,16 +208,16 @@ ExternalProject_Add(ava-spec
   BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated"
   INSTALL_COMMAND ""
   CMAKE_CACHE_ARGS
-        -DProtobuf_DIR:PATH=${_FINDPACKAGE_PROTOBUF_CONFIG_DIR}
+        -DProtobuf_DIR:PATH=${_Protobuf_DIR}
         -Dc-ares_DIR:PATH=${EXTERNAL_BINARY_DIR}/c-ares/lib/cmake/c-ares
         -DZLIB_ROOT:STRING=${EXTERNAL_BINARY_DIR}/zlib
         -Dabsl_DIR:STRING=${EXTERNAL_BINARY_DIR}/absl/lib/cmake/absl
         ${_CMAKE_ARGS_OPENSSL_ROOT_DIR}
-        -DgRPC_DIR:PATH=${EXTERNAL_BINARY_DIR}/grpc/lib/cmake/grpc
+        -DgRPC_DIR:PATH=${_gRPC_DIR}
         -DFlatbuffers_DIR:PATH=${EXTERNAL_BINARY_DIR}/flatbuffers/lib/cmake/flatbuffers
         -Dlibconfig++_DIR:PATH=${EXTERNAL_BINARY_DIR}/libconfig/lib/cmake/libconfig
         -DCMAKE_C_COMPILER:STRING=${CMAKE_C_COMPILER}
         -DCMAKE_CXX_COMPILER:STRING=${CMAKE_CXX_COMPILER}
   BUILD_ALWAYS ON
-  DEPENDS protobuf grpc flatbuffers libconfig
+  DEPENDS flatbuffers libconfig
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,7 @@ endif()
 ExternalProject_Add(grpc
   PREFIX grpc
   SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/third_party/grpc"
+  PATCH_COMMAND patch -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/third_party/grpc-gettid.patch
   CMAKE_CACHE_ARGS
         -DgRPC_INSTALL:BOOL=ON
         -DgRPC_BUILD_TESTS:BOOL=OFF
@@ -107,7 +108,7 @@ ExternalProject_Add(grpc
         -DgRPC_PROTOBUF_PACKAGE_TYPE:STRING=CONFIG
         -DProtobuf_DIR:PATH=${_FINDPACKAGE_PROTOBUF_CONFIG_DIR}
         -DgRPC_ZLIB_PROVIDER:STRING=package
-        -DZLIB_ROOT:STRING=${EXTERNAL_BINARY_DIR}/zlib
+        -DZLIB_DIR:STRING=${EXTERNAL_BINARY_DIR}/zlib
         -DgRPC_ABSL_PROVIDER:STRING=package
         -Dabsl_DIR:STRING=${EXTERNAL_BINARY_DIR}/absl/lib/cmake/absl
         -DgRPC_CARES_PROVIDER:STRING=package
@@ -151,7 +152,7 @@ ExternalProject_Add(ava-proto
   CMAKE_CACHE_ARGS
         -DProtobuf_DIR:PATH=${_FINDPACKAGE_PROTOBUF_CONFIG_DIR}
         -Dc-ares_DIR:PATH=${EXTERNAL_BINARY_DIR}/c-ares/lib/cmake/c-ares
-        -DZLIB_ROOT:STRING=${EXTERNAL_BINARY_DIR}/zlib
+        -DZLIB_DIR:STRING=${EXTERNAL_BINARY_DIR}/zlib
         -Dabsl_DIR:STRING=${EXTERNAL_BINARY_DIR}/absl/lib/cmake/absl
         ${_CMAKE_ARGS_OPENSSL_ROOT_DIR}
         -DgRPC_DIR:PATH=${EXTERNAL_BINARY_DIR}/grpc/lib/cmake/grpc
@@ -175,7 +176,7 @@ ExternalProject_Add(ava-manager
   CMAKE_CACHE_ARGS
         -DProtobuf_DIR:PATH=${_FINDPACKAGE_PROTOBUF_CONFIG_DIR}
         -Dc-ares_DIR:PATH=${EXTERNAL_BINARY_DIR}/c-ares/lib/cmake/c-ares
-        -DZLIB_ROOT:STRING=${EXTERNAL_BINARY_DIR}/zlib
+        -DZLIB_DIR:STRING=${EXTERNAL_BINARY_DIR}/zlib
         -Dabsl_DIR:STRING=${EXTERNAL_BINARY_DIR}/absl/lib/cmake/absl
         ${_CMAKE_ARGS_OPENSSL_ROOT_DIR}
         -DgRPC_DIR:PATH=${EXTERNAL_BINARY_DIR}/grpc/lib/cmake/grpc

--- a/cava/CMakeLists.txt
+++ b/cava/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.13)
+
 get_cmake_property(vars CACHE_VARIABLES)
 foreach(var ${vars})
   if (var MATCHES ".*_DIR$" OR var MATCHES ".*_ROOT$")

--- a/third_party/grpc-gettid.patch
+++ b/third_party/grpc-gettid.patch
@@ -1,0 +1,52 @@
+diff --git a/src/core/lib/gpr/log_linux.cc b/src/core/lib/gpr/log_linux.cc
+index 561276f0c2..c51182f0c2 100644
+
+glibc 2.30 declares gettid. Newer versions of grpc rename their own gettid
+function to avoid "ambiguating new declaration of 'long int gettid()'" [1] but
+upgrading grpc runs into other problems (protobuf, grpc, grpc+flatbuffer
+plugin).
+
+[1] https://github.com/grpc/grpc/pull/18950
+
+--- a/src/core/lib/gpr/log_linux.cc
++++ b/src/core/lib/gpr/log_linux.cc
+@@ -40,7 +40,7 @@
+ #include <time.h>
+ #include <unistd.h>
+ 
+-static long gettid(void) { return syscall(__NR_gettid); }
++static long _gettid(void) { return syscall(__NR_gettid); }
+ 
+ void gpr_log(const char* file, int line, gpr_log_severity severity,
+              const char* format, ...) {
+@@ -70,7 +70,7 @@ void gpr_default_log(gpr_log_func_args* args) {
+   gpr_timespec now = gpr_now(GPR_CLOCK_REALTIME);
+   struct tm tm;
+   static __thread long tid = 0;
+-  if (tid == 0) tid = gettid();
++  if (tid == 0) tid = _gettid();
+ 
+   timer = static_cast<time_t>(now.tv_sec);
+   final_slash = strrchr(args->file, '/');
+diff --git a/src/core/lib/iomgr/ev_epollex_linux.cc b/src/core/lib/iomgr/ev_epollex_linux.cc
+index b082634af1..7080d450df 100644
+--- a/src/core/lib/iomgr/ev_epollex_linux.cc
++++ b/src/core/lib/iomgr/ev_epollex_linux.cc
+@@ -1146,7 +1146,7 @@ static void end_worker(grpc_pollset* pollset, grpc_pollset_worker* worker,
+ }
+ 
+ #ifndef NDEBUG
+-static long gettid(void) { return syscall(__NR_gettid); }
++static long _gettid(void) { return syscall(__NR_gettid); }
+ #endif
+ 
+ /* pollset->mu lock must be held by the caller before calling this.
+@@ -1166,7 +1166,7 @@ static grpc_error* pollset_work(grpc_pollset* pollset,
+ #define WORKER_PTR (&worker)
+ #endif
+ #ifndef NDEBUG
+-  WORKER_PTR->originator = gettid();
++  WORKER_PTR->originator = _gettid();
+ #endif
+   if (grpc_polling_trace.enabled()) {
+     gpr_log(GPR_INFO,

--- a/worker/CMakeLists.txt
+++ b/worker/CMakeLists.txt
@@ -1,1 +1,2 @@
+cmake_minimum_required(VERSION 3.13)
 project(ava-manager)


### PR DESCRIPTION
This PR also avoid the rebuild of Protobuf and gRPC if they have been installed in the system.