### PR TITLE
Fix TensorFlow spec for tf_cnn_benchmarks

### DIFF
--- a/cava/samples/onnxruntime/onnx_dump.c
+++ b/cava/samples/onnxruntime/onnx_dump.c
@@ -7456,8 +7456,14 @@ cudnnGetConvolutionBackwardFilterWorkspaceSize(cudnnHandle_t handle,
                                                cudnnConvolutionBwdFilterAlgo_t algo,
                                                size_t *sizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __func__);
-    abort();
+  ava_argument(handle) ava_handle;
+  ava_argument(xDesc) ava_handle;
+  ava_argument(dyDesc) ava_handle;
+  ava_argument(convDesc) ava_handle;
+  ava_argument(gradDesc) ava_handle;
+  ava_argument(sizeInBytes) {
+    ava_out; ava_buffer(1);
+  }
 }
 
 cudnnStatus_t CUDNNWINAPI
@@ -7475,8 +7481,26 @@ cudnnConvolutionBackwardFilter(cudnnHandle_t handle,
                                const cudnnFilterDescriptor_t dwDesc,
                                void *dw)
 {
-    fprintf(stderr, "%s is not implemented\n", __func__);
-    abort();
+  ava_argument(handle) ava_handle;
+  ava_argument(alpha) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+
+  ava_argument(xDesc) ava_handle;
+  ava_argument(x) ava_opaque;
+  ava_argument(dyDesc) ava_handle;
+  ava_argument(dy) ava_opaque;
+
+  ava_argument(convDesc) ava_handle;
+  ava_argument(workSpace) ava_opaque;
+
+  ava_argument(beta) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(dwDesc) ava_handle;
+  ava_argument(dw) ava_opaque;
 }
 
 cudnnStatus_t CUDNNWINAPI
@@ -7598,9 +7622,7 @@ cudnnConvolutionBackwardData(cudnnHandle_t handle,
    ava_argument(dyDesc) ava_handle;
    ava_argument(dy) ava_opaque;
    ava_argument(convDesc) ava_handle;
-   ava_argument(workSpace) {
-     ava_in; ava_buffer(workSpaceSizeInBytes);
-   }
+   ava_argument(workSpace) ava_opaque;
 }
 
 cudnnStatus_t CUDNNWINAPI
@@ -8000,8 +8022,26 @@ cudnnBatchNormalizationForwardTraining(
     void *resultSaveMean,
     void *resultSaveInvVariance)
 {
-    fprintf(stderr, "%s is not implemented\n", __func__);
-    abort();
+  ava_argument(handle) ava_handle;
+  ava_argument(alpha) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(beta) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(xDesc) ava_handle;
+  ava_argument(x) ava_opaque;
+  ava_argument(yDesc) ava_handle;
+  ava_argument(y) ava_opaque;
+  ava_argument(bnScaleBiasMeanVarDesc) ava_handle;
+  ava_argument(bnScale) ava_opaque;
+  ava_argument(bnBias) ava_opaque;
+  ava_argument(resultRunningMean) ava_opaque;
+  ava_argument(resultRunningVariance) ava_opaque;
+  ava_argument(resultSaveMean) ava_opaque;
+  ava_argument(resultSaveInvVariance) ava_opaque;
 }
 
 /* Computes y = relu(BN(x) + z). Also accumulates moving averages of mean and inverse variances */
@@ -8043,8 +8083,36 @@ cudnnBatchNormalizationForwardTrainingEx(
     void *reserveSpace,
     size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __func__);
-    abort();
+  ava_argument(handle) ava_handle;
+  ava_argument(alpha) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(beta) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+
+  ava_argument(xDesc) ava_handle;
+  ava_argument(xData) ava_opaque;
+  ava_argument(yDesc) ava_handle;
+  ava_argument(yData) ava_opaque;
+  ava_argument(zDesc) ava_handle;
+  ava_argument(zData) ava_opaque;
+
+  ava_argument(bnScaleBiasMeanVarDesc) ava_handle;
+  ava_argument(bnScale) ava_opaque;
+  ava_argument(bnBias) ava_opaque;
+
+  ava_argument(resultRunningMean) ava_opaque;
+  ava_argument(resultRunningVariance) ava_opaque;
+  ava_argument(resultSaveMean) ava_opaque;
+  ava_argument(resultSaveInvVariance) ava_opaque;
+
+  ava_argument(activationDesc) ava_handle;
+  ava_argument(workspace) ava_opaque;
+  ava_argument(reserveSpace) ava_opaque;
+
 }
 
 /* Performs backward pass of Batch Normalization layer. Returns x gradient,
@@ -8076,8 +8144,36 @@ cudnnBatchNormalizationBackward(cudnnHandle_t handle,
                                 const void *savedMean,
                                 const void *savedInvVariance)
 {
-    fprintf(stderr, "%s is not implemented\n", __func__);
-    abort();
+  ava_argument(handle) ava_handle;
+  ava_argument(alphaDataDiff) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(betaDataDiff) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(alphaParamDiff) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(betaParamDiff) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+
+  ava_argument(xDesc) ava_handle;
+  ava_argument(x) ava_opaque;
+  ava_argument(dyDesc) ava_handle;
+  ava_argument(dy) ava_opaque;
+  ava_argument(dxDesc) ava_handle;
+  ava_argument(dx) ava_opaque;
+  ava_argument(dBnScaleBiasDesc) ava_handle;
+  ava_argument(bnScale) ava_opaque;
+  ava_argument(dBnScaleResult) ava_opaque;
+  ava_argument(dBnBiasResult) ava_opaque;
+  ava_argument(savedMean) ava_opaque;
+  ava_argument(savedInvVariance) ava_opaque;
 }
 
 cudnnStatus_t CUDNNWINAPI
@@ -8118,8 +8214,47 @@ cudnnBatchNormalizationBackwardEx(cudnnHandle_t handle,
                                   void *reserveSpace,
                                   size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __func__);
-    abort();
+  ava_argument(handle) ava_handle;
+  ava_argument(alphaDataDiff) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(betaDataDiff) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(alphaParamDiff) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(betaParamDiff) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+
+  ava_argument(xDesc) ava_handle;
+  ava_argument(xData) ava_opaque;
+  ava_argument(yDesc) ava_handle;
+  ava_argument(yData) ava_opaque;
+  ava_argument(dxDesc) ava_handle;
+  ava_argument(dxData) ava_opaque;
+  ava_argument(dyDesc) ava_handle;
+  ava_argument(dyData) ava_opaque;
+  ava_argument(dzDesc) ava_handle;
+  ava_argument(dzData) ava_opaque;
+
+  ava_argument(dBnScaleBiasDesc) ava_handle;
+  ava_argument(bnScaleData) ava_opaque;
+  ava_argument(bnBiasData) ava_opaque;
+  ava_argument(dBnScaleData) ava_opaque;
+  ava_argument(dBnBiasData) ava_opaque;
+
+  ava_argument(savedMean) ava_opaque;
+  ava_argument(savedInvVariance) ava_opaque;
+
+  ava_argument(activationDesc) ava_handle;
+  ava_argument(workSpace) ava_opaque;
+  ava_argument(reserveSpace) ava_opaque;
 }
 
 cudnnStatus_t CUDNNWINAPI

--- a/cava/samples/onnxruntime/onnx_opt.c
+++ b/cava/samples/onnxruntime/onnx_opt.c
@@ -8068,8 +8068,14 @@ cudnnGetConvolutionBackwardFilterWorkspaceSize(cudnnHandle_t handle,
                                                cudnnConvolutionBwdFilterAlgo_t algo,
                                                size_t *sizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __func__);
-    abort();
+  ava_argument(handle) ava_handle;
+  ava_argument(xDesc) ava_handle;
+  ava_argument(dyDesc) ava_handle;
+  ava_argument(convDesc) ava_handle;
+  ava_argument(gradDesc) ava_handle;
+  ava_argument(sizeInBytes) {
+    ava_out; ava_buffer(1);
+  }
 }
 
 cudnnStatus_t CUDNNWINAPI
@@ -8087,8 +8093,26 @@ cudnnConvolutionBackwardFilter(cudnnHandle_t handle,
                                const cudnnFilterDescriptor_t dwDesc,
                                void *dw)
 {
-    fprintf(stderr, "%s is not implemented\n", __func__);
-    abort();
+  ava_argument(handle) ava_handle;
+  ava_argument(alpha) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+
+  ava_argument(xDesc) ava_handle;
+  ava_argument(x) ava_opaque;
+  ava_argument(dyDesc) ava_handle;
+  ava_argument(dy) ava_opaque;
+
+  ava_argument(convDesc) ava_handle;
+  ava_argument(workSpace) ava_opaque;
+
+  ava_argument(beta) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(dwDesc) ava_handle;
+  ava_argument(dw) ava_opaque;
 }
 
 cudnnStatus_t CUDNNWINAPI
@@ -8210,9 +8234,7 @@ cudnnConvolutionBackwardData(cudnnHandle_t handle,
    ava_argument(dyDesc) ava_handle;
    ava_argument(dy) ava_opaque;
    ava_argument(convDesc) ava_handle;
-   ava_argument(workSpace) {
-     ava_in; ava_buffer(workSpaceSizeInBytes);
-   }
+   ava_argument(workSpace) ava_opaque;
 }
 
 cudnnStatus_t CUDNNWINAPI
@@ -8613,8 +8635,26 @@ cudnnBatchNormalizationForwardTraining(
     void *resultSaveMean,
     void *resultSaveInvVariance)
 {
-    fprintf(stderr, "%s is not implemented\n", __func__);
-    abort();
+  ava_argument(handle) ava_handle;
+  ava_argument(alpha) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(beta) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(xDesc) ava_handle;
+  ava_argument(x) ava_opaque;
+  ava_argument(yDesc) ava_handle;
+  ava_argument(y) ava_opaque;
+  ava_argument(bnScaleBiasMeanVarDesc) ava_handle;
+  ava_argument(bnScale) ava_opaque;
+  ava_argument(bnBias) ava_opaque;
+  ava_argument(resultRunningMean) ava_opaque;
+  ava_argument(resultRunningVariance) ava_opaque;
+  ava_argument(resultSaveMean) ava_opaque;
+  ava_argument(resultSaveInvVariance) ava_opaque;
 }
 
 /* Computes y = relu(BN(x) + z). Also accumulates moving averages of mean and inverse variances */
@@ -8656,8 +8696,36 @@ cudnnBatchNormalizationForwardTrainingEx(
     void *reserveSpace,
     size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __func__);
-    abort();
+  ava_argument(handle) ava_handle;
+  ava_argument(alpha) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(beta) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+
+  ava_argument(xDesc) ava_handle;
+  ava_argument(xData) ava_opaque;
+  ava_argument(yDesc) ava_handle;
+  ava_argument(yData) ava_opaque;
+  ava_argument(zDesc) ava_handle;
+  ava_argument(zData) ava_opaque;
+
+  ava_argument(bnScaleBiasMeanVarDesc) ava_handle;
+  ava_argument(bnScale) ava_opaque;
+  ava_argument(bnBias) ava_opaque;
+
+  ava_argument(resultRunningMean) ava_opaque;
+  ava_argument(resultRunningVariance) ava_opaque;
+  ava_argument(resultSaveMean) ava_opaque;
+  ava_argument(resultSaveInvVariance) ava_opaque;
+
+  ava_argument(activationDesc) ava_handle;
+  ava_argument(workspace) ava_opaque;
+  ava_argument(reserveSpace) ava_opaque;
+
 }
 
 /* Performs backward pass of Batch Normalization layer. Returns x gradient,
@@ -8689,8 +8757,36 @@ cudnnBatchNormalizationBackward(cudnnHandle_t handle,
                                 const void *savedMean,
                                 const void *savedInvVariance)
 {
-    fprintf(stderr, "%s is not implemented\n", __func__);
-    abort();
+  ava_argument(handle) ava_handle;
+  ava_argument(alphaDataDiff) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(betaDataDiff) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(alphaParamDiff) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(betaParamDiff) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+
+  ava_argument(xDesc) ava_handle;
+  ava_argument(x) ava_opaque;
+  ava_argument(dyDesc) ava_handle;
+  ava_argument(dy) ava_opaque;
+  ava_argument(dxDesc) ava_handle;
+  ava_argument(dx) ava_opaque;
+  ava_argument(dBnScaleBiasDesc) ava_handle;
+  ava_argument(bnScale) ava_opaque;
+  ava_argument(dBnScaleResult) ava_opaque;
+  ava_argument(dBnBiasResult) ava_opaque;
+  ava_argument(savedMean) ava_opaque;
+  ava_argument(savedInvVariance) ava_opaque;
 }
 
 cudnnStatus_t CUDNNWINAPI
@@ -8731,8 +8827,47 @@ cudnnBatchNormalizationBackwardEx(cudnnHandle_t handle,
                                   void *reserveSpace,
                                   size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __func__);
-    abort();
+  ava_argument(handle) ava_handle;
+  ava_argument(alphaDataDiff) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(betaDataDiff) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(alphaParamDiff) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(betaParamDiff) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+
+  ava_argument(xDesc) ava_handle;
+  ava_argument(xData) ava_opaque;
+  ava_argument(yDesc) ava_handle;
+  ava_argument(yData) ava_opaque;
+  ava_argument(dxDesc) ava_handle;
+  ava_argument(dxData) ava_opaque;
+  ava_argument(dyDesc) ava_handle;
+  ava_argument(dyData) ava_opaque;
+  ava_argument(dzDesc) ava_handle;
+  ava_argument(dzData) ava_opaque;
+
+  ava_argument(dBnScaleBiasDesc) ava_handle;
+  ava_argument(bnScaleData) ava_opaque;
+  ava_argument(bnBiasData) ava_opaque;
+  ava_argument(dBnScaleData) ava_opaque;
+  ava_argument(dBnBiasData) ava_opaque;
+
+  ava_argument(savedMean) ava_opaque;
+  ava_argument(savedInvVariance) ava_opaque;
+
+  ava_argument(activationDesc) ava_handle;
+  ava_argument(workSpace) ava_opaque;
+  ava_argument(reserveSpace) ava_opaque;
 }
 
 cudnnStatus_t CUDNNWINAPI

--- a/cava/samples/tensorflow/tf_dump.c
+++ b/cava/samples/tensorflow/tf_dump.c
@@ -7464,8 +7464,14 @@ cudnnGetConvolutionBackwardFilterWorkspaceSize(cudnnHandle_t handle,
                                                cudnnConvolutionBwdFilterAlgo_t algo,
                                                size_t *sizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __func__);
-    abort();
+  ava_argument(handle) ava_handle;
+  ava_argument(xDesc) ava_handle;
+  ava_argument(dyDesc) ava_handle;
+  ava_argument(convDesc) ava_handle;
+  ava_argument(gradDesc) ava_handle;
+  ava_argument(sizeInBytes) {
+    ava_out; ava_buffer(1);
+  }
 }
 
 cudnnStatus_t CUDNNWINAPI
@@ -7483,8 +7489,26 @@ cudnnConvolutionBackwardFilter(cudnnHandle_t handle,
                                const cudnnFilterDescriptor_t dwDesc,
                                void *dw)
 {
-    fprintf(stderr, "%s is not implemented\n", __func__);
-    abort();
+  ava_argument(handle) ava_handle;
+  ava_argument(alpha) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+
+  ava_argument(xDesc) ava_handle;
+  ava_argument(x) ava_opaque;
+  ava_argument(dyDesc) ava_handle;
+  ava_argument(dy) ava_opaque;
+
+  ava_argument(convDesc) ava_handle;
+  ava_argument(workSpace) ava_opaque;
+
+  ava_argument(beta) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(dwDesc) ava_handle;
+  ava_argument(dw) ava_opaque;
 }
 
 cudnnStatus_t CUDNNWINAPI
@@ -7606,9 +7630,7 @@ cudnnConvolutionBackwardData(cudnnHandle_t handle,
    ava_argument(dyDesc) ava_handle;
    ava_argument(dy) ava_opaque;
    ava_argument(convDesc) ava_handle;
-   ava_argument(workSpace) {
-     ava_in; ava_buffer(workSpaceSizeInBytes);
-   }
+   ava_argument(workSpace) ava_opaque;
 }
 
 cudnnStatus_t CUDNNWINAPI
@@ -8008,8 +8030,26 @@ cudnnBatchNormalizationForwardTraining(
     void *resultSaveMean,
     void *resultSaveInvVariance)
 {
-    fprintf(stderr, "%s is not implemented\n", __func__);
-    abort();
+  ava_argument(handle) ava_handle;
+  ava_argument(alpha) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(beta) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(xDesc) ava_handle;
+  ava_argument(x) ava_opaque;
+  ava_argument(yDesc) ava_handle;
+  ava_argument(y) ava_opaque;
+  ava_argument(bnScaleBiasMeanVarDesc) ava_handle;
+  ava_argument(bnScale) ava_opaque;
+  ava_argument(bnBias) ava_opaque;
+  ava_argument(resultRunningMean) ava_opaque;
+  ava_argument(resultRunningVariance) ava_opaque;
+  ava_argument(resultSaveMean) ava_opaque;
+  ava_argument(resultSaveInvVariance) ava_opaque;
 }
 
 /* Computes y = relu(BN(x) + z). Also accumulates moving averages of mean and inverse variances */
@@ -8051,8 +8091,35 @@ cudnnBatchNormalizationForwardTrainingEx(
     void *reserveSpace,
     size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __func__);
-    abort();
+  ava_argument(handle) ava_handle;
+  ava_argument(alpha) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(beta) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+
+  ava_argument(xDesc) ava_handle;
+  ava_argument(xData) ava_opaque;
+  ava_argument(yDesc) ava_handle;
+  ava_argument(yData) ava_opaque;
+  ava_argument(zDesc) ava_handle;
+  ava_argument(zData) ava_opaque;
+
+  ava_argument(bnScaleBiasMeanVarDesc) ava_handle;
+  ava_argument(bnScale) ava_opaque;
+  ava_argument(bnBias) ava_opaque;
+
+  ava_argument(resultRunningMean) ava_opaque;
+  ava_argument(resultRunningVariance) ava_opaque;
+  ava_argument(resultSaveMean) ava_opaque;
+  ava_argument(resultSaveInvVariance) ava_opaque;
+
+  ava_argument(activationDesc) ava_handle;
+  ava_argument(workspace) ava_opaque;
+  ava_argument(reserveSpace) ava_opaque;
 }
 
 /* Performs backward pass of Batch Normalization layer. Returns x gradient,
@@ -8084,8 +8151,36 @@ cudnnBatchNormalizationBackward(cudnnHandle_t handle,
                                 const void *savedMean,
                                 const void *savedInvVariance)
 {
-    fprintf(stderr, "%s is not implemented\n", __func__);
-    abort();
+  ava_argument(handle) ava_handle;
+  ava_argument(alphaDataDiff) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(betaDataDiff) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(alphaParamDiff) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(betaParamDiff) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+
+  ava_argument(xDesc) ava_handle;
+  ava_argument(x) ava_opaque;
+  ava_argument(dyDesc) ava_handle;
+  ava_argument(dy) ava_opaque;
+  ava_argument(dxDesc) ava_handle;
+  ava_argument(dx) ava_opaque;
+  ava_argument(dBnScaleBiasDesc) ava_handle;
+  ava_argument(bnScale) ava_opaque;
+  ava_argument(dBnScaleResult) ava_opaque;
+  ava_argument(dBnBiasResult) ava_opaque;
+  ava_argument(savedMean) ava_opaque;
+  ava_argument(savedInvVariance) ava_opaque;
 }
 
 cudnnStatus_t CUDNNWINAPI
@@ -8126,8 +8221,47 @@ cudnnBatchNormalizationBackwardEx(cudnnHandle_t handle,
                                   void *reserveSpace,
                                   size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __func__);
-    abort();
+  ava_argument(handle) ava_handle;
+  ava_argument(alphaDataDiff) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(betaDataDiff) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(alphaParamDiff) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(betaParamDiff) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+
+  ava_argument(xDesc) ava_handle;
+  ava_argument(xData) ava_opaque;
+  ava_argument(yDesc) ava_handle;
+  ava_argument(yData) ava_opaque;
+  ava_argument(dxDesc) ava_handle;
+  ava_argument(dxData) ava_opaque;
+  ava_argument(dyDesc) ava_handle;
+  ava_argument(dyData) ava_opaque;
+  ava_argument(dzDesc) ava_handle;
+  ava_argument(dzData) ava_opaque;
+
+  ava_argument(dBnScaleBiasDesc) ava_handle;
+  ava_argument(bnScaleData) ava_opaque;
+  ava_argument(bnBiasData) ava_opaque;
+  ava_argument(dBnScaleData) ava_opaque;
+  ava_argument(dBnBiasData) ava_opaque;
+
+  ava_argument(savedMean) ava_opaque;
+  ava_argument(savedInvVariance) ava_opaque;
+
+  ava_argument(activationDesc) ava_handle;
+  ava_argument(workSpace) ava_opaque;
+  ava_argument(reserveSpace) ava_opaque;
 }
 
 cudnnStatus_t CUDNNWINAPI

--- a/cava/samples/tensorflow/tf_opt.c
+++ b/cava/samples/tensorflow/tf_opt.c
@@ -8057,8 +8057,14 @@ cudnnGetConvolutionBackwardFilterWorkspaceSize(cudnnHandle_t handle,
                                                cudnnConvolutionBwdFilterAlgo_t algo,
                                                size_t *sizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __func__);
-    abort();
+  ava_argument(handle) ava_handle;
+  ava_argument(xDesc) ava_handle;
+  ava_argument(dyDesc) ava_handle;
+  ava_argument(convDesc) ava_handle;
+  ava_argument(gradDesc) ava_handle;
+  ava_argument(sizeInBytes) {
+    ava_out; ava_buffer(1);
+  }
 }
 
 cudnnStatus_t CUDNNWINAPI
@@ -8076,8 +8082,26 @@ cudnnConvolutionBackwardFilter(cudnnHandle_t handle,
                                const cudnnFilterDescriptor_t dwDesc,
                                void *dw)
 {
-    fprintf(stderr, "%s is not implemented\n", __func__);
-    abort();
+  ava_argument(handle) ava_handle;
+  ava_argument(alpha) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+
+  ava_argument(xDesc) ava_handle;
+  ava_argument(x) ava_opaque;
+  ava_argument(dyDesc) ava_handle;
+  ava_argument(dy) ava_opaque;
+
+  ava_argument(convDesc) ava_handle;
+  ava_argument(workSpace) ava_opaque;
+
+  ava_argument(beta) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(dwDesc) ava_handle;
+  ava_argument(dw) ava_opaque;
 }
 
 cudnnStatus_t CUDNNWINAPI
@@ -8199,9 +8223,7 @@ cudnnConvolutionBackwardData(cudnnHandle_t handle,
    ava_argument(dyDesc) ava_handle;
    ava_argument(dy) ava_opaque;
    ava_argument(convDesc) ava_handle;
-   ava_argument(workSpace) {
-     ava_in; ava_buffer(workSpaceSizeInBytes);
-   }
+   ava_argument(workSpace) ava_opaque;
 }
 
 cudnnStatus_t CUDNNWINAPI
@@ -8601,8 +8623,26 @@ cudnnBatchNormalizationForwardTraining(
     void *resultSaveMean,
     void *resultSaveInvVariance)
 {
-    fprintf(stderr, "%s is not implemented\n", __func__);
-    abort();
+  ava_argument(handle) ava_handle;
+  ava_argument(alpha) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(beta) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(xDesc) ava_handle;
+  ava_argument(x) ava_opaque;
+  ava_argument(yDesc) ava_handle;
+  ava_argument(y) ava_opaque;
+  ava_argument(bnScaleBiasMeanVarDesc) ava_handle;
+  ava_argument(bnScale) ava_opaque;
+  ava_argument(bnBias) ava_opaque;
+  ava_argument(resultRunningMean) ava_opaque;
+  ava_argument(resultRunningVariance) ava_opaque;
+  ava_argument(resultSaveMean) ava_opaque;
+  ava_argument(resultSaveInvVariance) ava_opaque;
 }
 
 /* Computes y = relu(BN(x) + z). Also accumulates moving averages of mean and inverse variances */
@@ -8644,8 +8684,35 @@ cudnnBatchNormalizationForwardTrainingEx(
     void *reserveSpace,
     size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __func__);
-    abort();
+  ava_argument(handle) ava_handle;
+  ava_argument(alpha) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(beta) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+
+  ava_argument(xDesc) ava_handle;
+  ava_argument(xData) ava_opaque;
+  ava_argument(yDesc) ava_handle;
+  ava_argument(yData) ava_opaque;
+  ava_argument(zDesc) ava_handle;
+  ava_argument(zData) ava_opaque;
+
+  ava_argument(bnScaleBiasMeanVarDesc) ava_handle;
+  ava_argument(bnScale) ava_opaque;
+  ava_argument(bnBias) ava_opaque;
+
+  ava_argument(resultRunningMean) ava_opaque;
+  ava_argument(resultRunningVariance) ava_opaque;
+  ava_argument(resultSaveMean) ava_opaque;
+  ava_argument(resultSaveInvVariance) ava_opaque;
+
+  ava_argument(activationDesc) ava_handle;
+  ava_argument(workspace) ava_opaque;
+  ava_argument(reserveSpace) ava_opaque;
 }
 
 /* Performs backward pass of Batch Normalization layer. Returns x gradient,
@@ -8677,8 +8744,36 @@ cudnnBatchNormalizationBackward(cudnnHandle_t handle,
                                 const void *savedMean,
                                 const void *savedInvVariance)
 {
-    fprintf(stderr, "%s is not implemented\n", __func__);
-    abort();
+  ava_argument(handle) ava_handle;
+  ava_argument(alphaDataDiff) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(betaDataDiff) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(alphaParamDiff) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(betaParamDiff) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+
+  ava_argument(xDesc) ava_handle;
+  ava_argument(x) ava_opaque;
+  ava_argument(dyDesc) ava_handle;
+  ava_argument(dy) ava_opaque;
+  ava_argument(dxDesc) ava_handle;
+  ava_argument(dx) ava_opaque;
+  ava_argument(dBnScaleBiasDesc) ava_handle;
+  ava_argument(bnScale) ava_opaque;
+  ava_argument(dBnScaleResult) ava_opaque;
+  ava_argument(dBnBiasResult) ava_opaque;
+  ava_argument(savedMean) ava_opaque;
+  ava_argument(savedInvVariance) ava_opaque;
 }
 
 cudnnStatus_t CUDNNWINAPI
@@ -8719,8 +8814,47 @@ cudnnBatchNormalizationBackwardEx(cudnnHandle_t handle,
                                   void *reserveSpace,
                                   size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __func__);
-    abort();
+  ava_argument(handle) ava_handle;
+  ava_argument(alphaDataDiff) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(betaDataDiff) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(alphaParamDiff) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+  ava_argument(betaParamDiff) {
+    ava_type_cast(const double *);
+    ava_in; ava_buffer(1);
+  }
+
+  ava_argument(xDesc) ava_handle;
+  ava_argument(xData) ava_opaque;
+  ava_argument(yDesc) ava_handle;
+  ava_argument(yData) ava_opaque;
+  ava_argument(dxDesc) ava_handle;
+  ava_argument(dxData) ava_opaque;
+  ava_argument(dyDesc) ava_handle;
+  ava_argument(dyData) ava_opaque;
+  ava_argument(dzDesc) ava_handle;
+  ava_argument(dzData) ava_opaque;
+
+  ava_argument(dBnScaleBiasDesc) ava_handle;
+  ava_argument(bnScaleData) ava_opaque;
+  ava_argument(bnBiasData) ava_opaque;
+  ava_argument(dBnScaleData) ava_opaque;
+  ava_argument(dBnBiasData) ava_opaque;
+
+  ava_argument(savedMean) ava_opaque;
+  ava_argument(savedInvVariance) ava_opaque;
+
+  ava_argument(activationDesc) ava_handle;
+  ava_argument(workSpace) ava_opaque;
+  ava_argument(reserveSpace) ava_opaque;
 }
 
 cudnnStatus_t CUDNNWINAPI


### PR DESCRIPTION
This PR annotates more APIs required for running [tensorflow/benchmarks/tf_cnn_benchmarks](https://github.com/tensorflow/benchmarks/tree/master/scripts/tf_cnn_benchmarks).

```
$ LD_LIBRARY_PATH=/home/ubuntu/ava-build/install/tf_opt/lib python3 tf_cnn_benchmarks.py --num_gpus=1 --batch_size=32 --model=resnet50 --variable_update=parameter_server

Done warm up
Step    Img/sec total_loss
1       images/sec: 135.5 +/- 0.0 (jitter = 0.0)        8.169
10      images/sec: 133.2 +/- 2.3 (jitter = 7.3)        7.593
20      images/sec: 133.6 +/- 1.4 (jitter = 5.5)        7.696
30      images/sec: 133.6 +/- 1.0 (jitter = 4.7)        7.753
40      images/sec: 134.4 +/- 0.9 (jitter = 5.4)        8.007
50      images/sec: 134.4 +/- 0.8 (jitter = 5.0)        7.520
60      images/sec: 134.2 +/- 0.7 (jitter = 5.0)        7.989
70      images/sec: 134.2 +/- 0.6 (jitter = 5.1)        8.028
80      images/sec: 133.9 +/- 0.6 (jitter = 5.0)        7.932
90      images/sec: 133.8 +/- 0.6 (jitter = 4.8)        7.850
100     images/sec: 133.8 +/- 0.5 (jitter = 4.9)        7.796
----------------------------------------------------------------
total images/sec: 133.81
----------------------------------------------------------------
```