### PR TITLE
Fix the signal handler in legacy manager

### DIFF
--- a/worker/include/manager_service.h
+++ b/worker/include/manager_service.h
@@ -22,6 +22,11 @@ public:
     io_service_.run();
   }
 
+  void StopServer() {
+    std::cerr << "Stopping Manager service" << std::endl;
+    io_service_.stop();
+  }
+
 private:
   void AcceptConnection();
   void HandleAccept(std::unique_ptr<boost::asio::ip::tcp::socket> socket,


### PR DESCRIPTION
This partially addresses #69, use boost::asio::io_service::stop for the legacy manager. Will this approach apply to other managers? How can I easily test them...