### PR TITLE
Add ava_soname rule for guestlib name

### DIFF
--- a/cava/lapis.md
+++ b/cava/lapis.md
@@ -39,11 +39,13 @@ ava_name("name");
 ava_version("version");
 ava_identifier(id);
 ava_number(id_number);
+ava_soname(so_name);
 ```
 Specify the name, version, and identifiers of the API as a whole.
 The `id` is a short C identifier used to differential API related symbol names in Lapis compilers.
 The `id_number` is an integer which used by the Lapis compiler to identify the API when a number is needed.
-The `id_number` should be unique within a configuration so as distinguish all APIs used. 
+The `id_number` should be unique within a configuration so as distinguish all APIs used.
+The `ava_soname` is the name for the generated library file (e.g. libguestlib.so). Default is "guestlib".
 
 ```c
 ava_cflags(flags);

--- a/cava/nightwatch/generator/c/cmakelists.py
+++ b/cava/nightwatch/generator/c/cmakelists.py
@@ -74,7 +74,7 @@ target_link_libraries(worker
   {api.libs}
 )
 
-add_library(guestlib SHARED
+add_library({api.soname} SHARED
   ${{CMAKE_SOURCE_DIR}}/../../guestlib/src/init.cpp
   ${{CMAKE_SOURCE_DIR}}/../../guestlib/src/guest_config.cpp
   ${{CMAKE_SOURCE_DIR}}/../../common/cmd_channel_shm.c
@@ -94,19 +94,19 @@ add_library(guestlib SHARED
   ${{CMAKE_SOURCE_DIR}}/../../common/cmd_channel_socket_vsock.cpp
   ${{CMAKE_SOURCE_DIR}}/../../proto/manager_service.proto.cpp
 )
-target_link_libraries(guestlib
+target_link_libraries({api.soname}
   ${{GLIB2_LIBRARIES}}
   ${{Boost_LIBRARIES}}
   Threads::Threads
   ${{Config++}}
 )
-target_compile_options(guestlib
+target_compile_options({api.soname}
   PUBLIC -fvisibility=hidden
 )
 include(GNUInstallDirs)
 install(TARGETS worker
         RUNTIME DESTINATION ${{CMAKE_INSTALL_BINDIR}})
-install(TARGETS guestlib
+install(TARGETS {api.soname}
         LIBRARY DESTINATION ${{CMAKE_INSTALL_LIBDIR}})
     """.strip()
     return "CMakeLists.txt", cmakelists

--- a/cava/nightwatch/model.py
+++ b/cava/nightwatch/model.py
@@ -523,6 +523,7 @@ class API(object):
         self.metadata_type = metadata_type
         self.libs = ""
         self.cflags = ""
+        self.soname = "guestlib"
         self.cxxflags = ""
         self.guestlib_srcs = ""
         self.worker_srcs = ""

--- a/cava/nightwatch/parser/c/nightwatch.h
+++ b/cava/nightwatch/parser/c/nightwatch.h
@@ -359,6 +359,7 @@ typedef void (*ava_replace_function)(void* obj, void* data, size_t length);
 #define ava_cflags(n) const char* __AVA_NAME(cflags) = __STRINGIFY(n)
 #define ava_cxxflags(n) const char* __AVA_NAME(cxxflags) = __STRINGIFY(n)
 #define ava_libs(n) const char* __AVA_NAME(libs) = __STRINGIFY(n)
+#define ava_soname(n) const char* __AVA_NAME(soname) = __STRINGIFY(n)
 
 #define ava_guestlib_srcs(n) const char* __AVA_NAME(guestlib_srcs) = __STRINGIFY(n)
 #define ava_worker_srcs(n) const char* __AVA_NAME(worker_srcs) = __STRINGIFY(n)

--- a/cava/samples/cudadrv/CMakeLists.txt
+++ b/cava/samples/cudadrv/CMakeLists.txt
@@ -26,7 +26,7 @@ set(cudadrv_install ${AVA_INSTALL_DIR}/cudadrv)
 ExternalProject_Add_Step(cava cudadrv-link
   COMMAND mkdir -p generated &&
           mkdir -p ${cudadrv_install}/lib &&
-          ln -f -s ${cudadrv_install}/lib/libguestlib.so ${cudadrv_install}/lib/libcuda.so.1
+          ln -f -s ${cudadrv_install}/lib/libcuda.so ${cudadrv_install}/lib/libcuda.so.1
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/..
   DEPENDEES cudadrv-nwcc
 )

--- a/cava/samples/cudadrv/cuda_driver.c
+++ b/cava/samples/cudadrv/cuda_driver.c
@@ -4,6 +4,7 @@ ava_identifier(CUDADRV);
 ava_number(3);
 ava_cflags(-I/usr/local/cuda/include);
 ava_libs(-lcuda);
+ava_soname(cuda);
 ava_export_qualifier();
 
 ava_non_transferable_types {


### PR DESCRIPTION
This allows the spec file to specify what the generated library is named

This is necessary for correct operation when applications dlopen a library.
The guestlib name must match the original library name.