### PR TITLE
Manager forward args to execvpe

### DIFF
--- a/worker/demo/manager.cpp
+++ b/worker/demo/manager.cpp
@@ -13,8 +13,8 @@ const uint32_t kDefaultWorkerPortBase = 4000;
 
 class DemoManager : public ManagerServiceServerBase {
 public:
-  DemoManager(uint32_t port, uint32_t worker_port_base, std::string worker_path) :
-    ManagerServiceServerBase(port, worker_port_base, worker_path) {}
+  DemoManager(uint32_t port, uint32_t worker_port_base, const char** worker_argv, int worker_argc) :
+    ManagerServiceServerBase(port, worker_port_base, worker_argc, worker_argv) {}
 private:
 };
 

--- a/worker/include/manager_service.h
+++ b/worker/include/manager_service.h
@@ -14,8 +14,13 @@ namespace ava_manager {
 
 class ManagerServiceServerBase {
 public:
+  /**
+   * @brief Start a manager service that will exec a worker when a connection is accepted
+   * @param worker_argv arguments to forward to exec
+   * @param worker_argc number of arguments in worker_argv
+   */
   ManagerServiceServerBase(uint32_t manager_port, uint32_t worker_port_base,
-      std::string worker_path);
+                           const char **worker_argv, int worker_argc);
 
   void RunServer() {
     std::cerr << "Manager Service listening on ::" << manager_port_ << std::endl;
@@ -40,10 +45,12 @@ protected:
 
   uint32_t manager_port_;
   uint32_t worker_port_base_;
-  std::string worker_path_;
-
   std::atomic<uint32_t> worker_id_;
   std::map<pid_t, std::shared_ptr<std::thread>> worker_monitor_map_;
+
+  const char** const worker_argv_{NULL};
+  const int worker_argc_{0};
+
 };
 
 }  // namespace ava_manager


### PR DESCRIPTION
Forward argc and argv from the manager to the execvpe command for the worker

This allows for ava to launch user-defined worker commands