### PR TITLE
Use plog as multi-severity-level logger

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,3 +3,8 @@
 	url = https://github.com/utcs-scea/ava-llvm.git
 	branch = v7.1.0
   ignore = dirty
+[submodule "third_party/plog"]
+	path = third_party/plog
+	url = https://github.com/SergiusTheBest/plog.git
+  branch = 1.1.5
+  ignore = dirty

--- a/cava/nightwatch/generator/c/cmakelists.py
+++ b/cava/nightwatch/generator/c/cmakelists.py
@@ -44,6 +44,7 @@ include_directories(
   ${{CMAKE_SOURCE_DIR}}/../../guestlib/include
   ${{CMAKE_SOURCE_DIR}}/../../proto
   ${{GLIB2_INCLUDE_DIRS}}
+  ${{CMAKE_SOURCE_DIR}}/../../third_party/plog/include
 )
 add_definitions(-D_GNU_SOURCE)
 

--- a/cava/nightwatch/generator/c/cmakelists.py
+++ b/cava/nightwatch/generator/c/cmakelists.py
@@ -51,7 +51,7 @@ add_definitions(-D_GNU_SOURCE)
 add_executable(worker
   ${{CMAKE_SOURCE_DIR}}/../../worker/worker.cpp
   ${{CMAKE_SOURCE_DIR}}/../../worker/cmd_channel_socket_tcp.cpp
-  ${{CMAKE_SOURCE_DIR}}/../../common/cmd_channel_shm_worker.c
+  ${{CMAKE_SOURCE_DIR}}/../../common/cmd_channel_shm_worker.cpp
   ${{CMAKE_SOURCE_DIR}}/../../worker/provision_gpu.cpp
   {' '.join(worker_srcs)}
   {api.c_worker_spelling}

--- a/common/cmd_channel_record.cpp
+++ b/common/cmd_channel_record.cpp
@@ -2,6 +2,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
+#include <plog/Log.h>
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
@@ -138,7 +139,7 @@ ssize_t command_channel_log_transfer_command(struct command_channel_log *c, cons
       .flags = 0,
   };
 
-  DEBUG_PRINT("record command %lu size %lx\n", cmd->command_id, metadata.size);
+  LOG_DEBUG << "record command " << cmd->command_id << " size " << std::hex << metadata.size;
   ssize_t ret;
   ret = write(chan->fd, &metadata, sizeof(struct record_command_metadata));
   if (ret == -1) {
@@ -265,7 +266,7 @@ struct command_channel_log *command_channel_log_new(int worker_port) {
   sprintf(fname, "record_log_worker_%d.bin", worker_port);
   chan->fd = open(fname, O_RDWR | O_CREAT | O_TRUNC, 0600);
   unlink(fname);
-  DEBUG_PRINT("temporary file %s created for recording\n", fname);
+  LOG_INFO << "temporary file %s created for recording" << fname;
 
   return chan;
 }

--- a/common/cmd_channel_socket_utilities.cpp
+++ b/common/cmd_channel_socket_utilities.cpp
@@ -3,6 +3,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <netinet/tcp.h>
+#include <plog/Log.h>
 #include <string.h>
 #include <unistd.h>
 
@@ -18,22 +19,6 @@ namespace chansocketutil {
  * Print a command for debugging.
  */
 void command_channel_socket_print_command(const struct command_channel *chan, const struct command_base *cmd) {
-  /*
-  DEBUG_PRINT("struct command_base {\n"
-              "  command_type=%ld\n"
-              "  flags=%d\n"
-              "  api_id=%d\n"
-              "  command_id=%ld\n"
-              "  command_size=%lx\n"
-              "  region_size=%lx\n"
-              "}\n",
-              cmd->command_type,
-              cmd->flags,
-              cmd->api_id,
-              cmd->command_id,
-              cmd->command_size,
-              cmd->region_size);
-  */
   DEBUG_PRINT_COMMAND(chan, cmd);
 }
 
@@ -159,7 +144,7 @@ struct command_base *command_channel_socket_receive_command(struct command_chann
 
   /* terminate guestlib when worker exits */
   if (chan->pfd.revents & POLLRDHUP) {
-    DEBUG_PRINT("command_channel_socket shutdown\n");
+    LOG_WARNING << "command_channel_socket shutdown";
     close(chan->pfd.fd);
     exit(-1);
   }

--- a/common/cmd_channel_socket_vsock.cpp
+++ b/common/cmd_channel_socket_vsock.cpp
@@ -4,6 +4,7 @@
 #include <fcntl.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
+#include <plog/Log.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
@@ -64,7 +65,7 @@ struct command_channel *command_channel_socket_new() {
   close(manager_fd);
 
   /* connect worker */
-  DEBUG_PRINT("assigned worker at %lu\n", worker_port);
+  LOG_INFO << "assigned worker at " << worker_port;
   chan->sock_fd = init_vm_socket(&sa, VMADDR_CID_HOST, worker_port);
   // FIXME: connect is always non-blocking for vm socket!
   if (!getenv("AVA_WPOOL") || !strcmp(getenv("AVA_WPOOL"), "FALSE")) usleep(2000000);

--- a/common/shadow_thread_pool.cpp
+++ b/common/shadow_thread_pool.cpp
@@ -5,6 +5,7 @@
 #include "common/shadow_thread_pool.hpp"
 
 #include <assert.h>
+#include <plog/Log.h>
 #include <stdio.h>
 
 #include "common/cmd_handler.hpp"
@@ -34,7 +35,7 @@ static void *shadow_thread_loop(void *arg);
 
 struct shadow_thread_t *shadow_thread_new(struct shadow_thread_pool_t *pool, intptr_t ava_id) {
   assert(g_hash_table_lookup(pool->threads, (gpointer)ava_id) == NULL);
-  DEBUG_PRINT("Creating shadow thread id = %lx\n", ava_id);
+  LOG_DEBUG << "Creating shadow thread id = " << ava_id;
   struct shadow_thread_t *t = (struct shadow_thread_t *)malloc(sizeof(struct shadow_thread_t));
   t->ava_id = ava_id;
   t->queue = g_async_queue_new_full(NULL);

--- a/common/socket.cpp
+++ b/common/socket.cpp
@@ -4,6 +4,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <netinet/tcp.h>
+#include <plog/Log.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/select.h>
@@ -129,7 +130,7 @@ int conn_vm_socket(int sockfd, struct sockaddr_vm *sa) {
 
   sock_flags = fcntl(sockfd, F_GETFL);
   if (sock_flags & O_NONBLOCK) {
-      DEBUG_PRINT("socket was non-blocking\n");
+      LOG_INGO << socket was non-blocking";
       if (fcntl(sockfd, F_SETFL, sock_flags & (~O_NONBLOCK)) < 0) {
           perror("fcntl blocking");
           exit(0);
@@ -155,7 +156,7 @@ int conn_vm_socket(int sockfd, struct sockaddr_vm *sa) {
 
   sock_flags = fcntl(sockfd, F_GETFL);
   if ((sock_flags & O_NONBLOCK) == 0) {
-    DEBUG_PRINT("socket was blocking\n");
+    LOG_INFO << "socket was blocking";
     if (fcntl(sockfd, F_SETFL, sock_flags | O_NONBLOCK) < 0) {
       perror("fcntl non-blocking");
       exit(0);
@@ -165,7 +166,7 @@ int conn_vm_socket(int sockfd, struct sockaddr_vm *sa) {
   ret = connect(sockfd, (struct sockaddr *)sa, sizeof(*sa));
   if (ret < 0) {
     if (errno == EINPROGRESS) {
-      DEBUG_PRINT("EINPROGRESS in connect() - selecting\n");
+      LOG_INFO << "EINPROGRESS in connect() - selecting";
 
       tv.tv_sec = 5;
       tv.tv_usec = 0;
@@ -174,13 +175,12 @@ int conn_vm_socket(int sockfd, struct sockaddr_vm *sa) {
       ret = select(sockfd + 1, NULL, &wset, NULL, &tv);
       if (ret > 0) {
         ret = 0;
-        DEBUG_PRINT("connect!\n");
         goto connect_exit;
       }
     }
   }
   if (!ret) {
-    DEBUG_PRINT("connection failed with errcode=%s...\n", strerror(errno));
+    LOG_ERROR << "connection failed with errcode=" << strerror(errno) << "...";
   }
 
 connect_exit:

--- a/config/README.md
+++ b/config/README.md
@@ -16,3 +16,4 @@ Run `setup.sh` to install an example configuration.
 | instance_type    | "ava.xlarge"   | Ignored        | Service instance type                   |
 | gpu_count        | 2              | Ignored        | Number of requested GPU, currently represented by `gpu_memory.size()` |
 | gpu_memory       | [1024L,512LL]  | []             | Requested GPU memory sizes, in MB       |
+| log_level        | "info"         | "info"         | Logger severity (verbose\|debug\|info\|warning\|error\|fatal\|none) |

--- a/config/guest.conf.example
+++ b/config/guest.conf.example
@@ -1,4 +1,5 @@
 channel = "TCP";
-connect_timeout = 5000L;
+connect_timeout = 5000L; # in milliseconds
 manager_address = "0.0.0.0:3334";
 gpu_memory = [1024L];
+log_level = "info";

--- a/guestlib/include/guest_config.h
+++ b/guestlib/include/guest_config.h
@@ -1,6 +1,8 @@
 #ifndef AVA_GUESTLIB_GUEST_CONFIG_H_
 #define AVA_GUESTLIB_GUEST_CONFIG_H_
 
+#include <plog/Severity.h>
+
 #include <iostream>
 #include <libconfig.h++>
 #include <memory>
@@ -13,12 +15,18 @@ constexpr char kConfigFilePath[] = "/etc/ava/guest.conf";
 constexpr char kDefaultChannel[] = "TCP";
 constexpr uint64_t kDefaultConnectTimeout = 5000;
 constexpr char kDefaultManagerAddress[] = "0.0.0.0:3334";
+constexpr char kDefaultLoggerSeverity[] = "info";
+constexpr plog::Severity kDefaultLoggerSeverityNumber = plog::info;
 
 class GuestConfig {
  public:
   GuestConfig(std::string chan, std::string manager_addr, uint64_t connect_timeout = kDefaultConnectTimeout,
-              std::vector<uint64_t> gpu_mem = {})
-      : channel_(chan), manager_address_(manager_addr), connect_timeout_(connect_timeout), gpu_memory_(gpu_mem) {}
+              std::vector<uint64_t> gpu_mem = {}, plog::Severity log_level = kDefaultLoggerSeverityNumber)
+      : channel_(chan),
+        manager_address_(manager_addr),
+        connect_timeout_(connect_timeout),
+        gpu_memory_(gpu_mem),
+        logger_severity_(log_level) {}
 
   void print() {
     std::cerr << "GuestConfig {" << std::endl
@@ -29,7 +37,7 @@ class GuestConfig {
               << "  gpu_count = (ignored)" << std::endl
               << "  gpu_memory = [";
     for (auto m : gpu_memory_) std::cerr << m << "M,";
-    std::cerr << "]" << std::endl;
+    std::cerr << "]" << std::endl << "  log_level = " << plog::severityToString(logger_severity_) << std::endl;
   }
 
   std::string channel_;
@@ -38,6 +46,7 @@ class GuestConfig {
   std::string instance_type_;  // not used
   int gpu_count_;              // not used, represented by gpu_memory_.size()
   std::vector<uint64_t> gpu_memory_;
+  plog::Severity logger_severity_;
 };
 
 std::shared_ptr<GuestConfig> readGuestConfig();

--- a/guestlib/src/cmd_channel_socket_tcp.cpp
+++ b/guestlib/src/cmd_channel_socket_tcp.cpp
@@ -1,3 +1,5 @@
+#include <plog/Log.h>
+
 #include <boost/algorithm/string.hpp>
 #include <boost/asio.hpp>
 #include <chrono>
@@ -63,7 +65,7 @@ std::vector<struct command_channel *> command_channel_socket_tcp_guest_new() {
     worker_address.push_back(wa);
   }
   if (worker_address.empty()) {
-    fprintf(stderr, "No API server is assigned");
+    LOG_ERROR << "No API server is assigned";
   }
 
   /* Connect API servers. */
@@ -83,7 +85,7 @@ std::vector<struct command_channel *> command_channel_socket_tcp_guest_new() {
     parseServerAddress(wa.c_str(), &worker_server_info, worker_name, &worker_port);
     assert(worker_server_info != NULL && "Unknown API server address");
     assert(worker_port > 0 && "Invalid API server port");
-    DEBUG_PRINT("Assigned worker at %s:%d\n", worker_name, worker_port);
+    LOG_INFO << "Assigned worker at " << worker_name << ":" << worker_port;
 
     chan->vm_id = nw_global_vm_id = 1;
     chan->listen_port = nw_worker_id = worker_port;

--- a/guestlib/src/init.cpp
+++ b/guestlib/src/init.cpp
@@ -1,7 +1,8 @@
-#include <stdio.h>
+#include <plog/Log.h>
 #include <stdlib.h>
 #include <unistd.h>
 
+#include <cstdio>
 #include <iostream>
 #include <vector>
 
@@ -11,7 +12,7 @@
 #include "common/linkage.h"
 #include "guest_config.h"
 #include "guestlib.h"
-
+#include "plog/Initializers/RollingFileInitializer.h"
 struct command_channel *chan;
 
 struct param_block_info nw_global_pb_info = {0, 0};
@@ -27,6 +28,11 @@ EXPORTED_WEAKLY void nw_init_guestlib(intptr_t api_id) {
 #ifdef DEBUG
   guestconfig::config->print();
 #endif
+
+  // Initialize logger
+  std::string log_file = std::tmpnam(nullptr);
+  plog::init(guestconfig::config->logger_severity_, log_file.c_str());
+  std::cerr << "To check the state of AvA remoting progress, use `tail -f " << log_file << "`" << std::endl;
 
 #ifdef AVA_PRINT_TIMESTAMP
   struct timeval ts;

--- a/worker/CMakeLists.txt
+++ b/worker/CMakeLists.txt
@@ -16,6 +16,7 @@ include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}/../include
   ${CMAKE_CURRENT_SOURCE_DIR}/include
   ${CMAKE_CURRENT_SOURCE_DIR}/../proto
+  ${CMAKE_CURRENT_SOURCE_DIR}/../third_party/plog/include
 )
 set(manager_service_proto_srcs "${CMAKE_CURRENT_SOURCE_DIR}/../proto/manager_service.proto.cpp")
 set(manager_service_ava_srcs   "${CMAKE_CURRENT_SOURCE_DIR}/manager_service.cpp"

--- a/worker/include/worker.h
+++ b/worker/include/worker.h
@@ -8,6 +8,8 @@
 #include "common/cmd_channel.hpp"
 
 #ifdef __cplusplus
+#include <plog/Log.h>
+
 #include <vector>
 
 extern "C" {


### PR DESCRIPTION
This introduces plog as the default logger in AvA. When guestlib and worker start, they will generate a random tmp file and output the logging information there.