### PR TITLE
Validate cflags before generating codes

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Download ava-llvm and generate codes
       if: startsWith(matrix.os, 'ubuntu-')
       run: |
-        python3 generate.py -s demo test
+        python3 generate.py -f -s demo test
 
     ###
     # Standard CMake build process

--- a/.github/workflows/build_and_test_cuda.yml
+++ b/.github/workflows/build_and_test_cuda.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Download ava-llvm and generate codes
       if: startsWith(matrix.os, 'ubuntu-')
       run: |
-        python3 generate.py -s cudadrv cudart
+        python3 generate.py -f -s cudadrv cudart
 
     ###
     # Standard CMake build process

--- a/cava/nightwatch/generator/c/cmakelists.py
+++ b/cava/nightwatch/generator/c/cmakelists.py
@@ -67,6 +67,7 @@ target_link_libraries(${{SUBPROJECT_PREFIX}}_worker
   ${{GLIB2_LIBRARIES}}
   ${{Boost_LIBRARIES}}
   Threads::Threads
+  fmt::fmt
   {api.libs}
 )
 set_target_properties(${{SUBPROJECT_PREFIX}}_worker PROPERTIES OUTPUT_NAME "worker")
@@ -96,6 +97,7 @@ target_link_libraries(${{SUBPROJECT_PREFIX}}_guestlib
   ${{GLIB2_LIBRARIES}}
   ${{Boost_LIBRARIES}}
   Threads::Threads
+  fmt::fmt
   ${{Config++}}
 )
 target_compile_options(${{SUBPROJECT_PREFIX}}_guestlib


### PR DESCRIPTION
## Description
This checks whether the nwcc input cflags are valid. If not, warning messages will be printed.
This PR also links fmt::fmt library explicitly to avoid potential linking error.

## Motivation and Context
```
[ 41%] Linking CXX executable worker
CMakeFiles/pt_opt_worker.dir/__/__/worker/worker.cpp.o: In function `main':
/anjuna/ava/worker/worker.cpp:93: warning: the use of `tmpnam' is dangerous, better use `mkstemp'
CMakeFiles/pt_opt_worker.dir/__/__/common/logging.cpp.o: In function `void ava::logging::MakeCheckOpValueString<char>(std::ostream*, char const&)':
/anjuna/ava/third_party/fmt/include/fmt/core.h:2076: undefined reference to `fmt::v7::detail::vformat[abi:cxx11](fmt::v7::basic_string_view<char>, fmt::v7::format_args)'
/anjuna/ava/third_party/fmt/include/fmt/core.h:2076: undefined reference to `fmt::v7::detail::vformat[abi:cxx11](fmt::v7::basic_string_view<char>, fmt::v7::format_args)'
CMakeFiles/pt_opt_worker.dir/__/__/common/logging.cpp.o: In function `void ava::logging::MakeCheckOpValueString<signed char>(std::ostream*, signed char const&)':
/anjuna/ava/third_party/fmt/include/fmt/core.h:2076: undefined reference to `fmt::v7::detail::vformat[abi:cxx11](fmt::v7::basic_string_view<char>, fmt::v7::format_args)'
/anjuna/ava/third_party/fmt/include/fmt/core.h:2076: undefined reference to `fmt::v7::detail::vformat[abi:cxx11](fmt::v7::basic_string_view<char>, fmt::v7::format_args)'
CMakeFiles/pt_opt_worker.dir/__/__/common/logging.cpp.o: In function `void ava::logging::MakeCheckOpValueString<unsigned char>(std::ostream*, unsigned char const&)':
/anjuna/ava/third_party/fmt/include/fmt/core.h:2076: undefined reference to `fmt::v7::detail::vformat[abi:cxx11](fmt::v7::basic_string_view<char>, fmt::v7::format_args)'
CMakeFiles/pt_opt_worker.dir/__/__/common/logging.cpp.o:/anjuna/ava/third_party/fmt/include/fmt/core.h:2076: more undefined references to `fmt::v7::detail::vformat[abi:cxx11](fmt::v7::basic_string_view<char>, fmt::v7::format_args)' follow
collect2: error: ld returned 1 exit status
cava/pt_opt_nw/CMakeFiles/pt_opt_worker.dir/build.make:358: recipe for target 'cava/pt_opt_nw/worker' failed
make[2]: *** [cava/pt_opt_nw/worker] Error 1
CMakeFiles/Makefile2:3110: recipe for target 'cava/pt_opt_nw/CMakeFiles/pt_opt_worker.dir/all' failed
make[1]: *** [cava/pt_opt_nw/CMakeFiles/pt_opt_worker.dir/all] Error 2
Makefile:148: recipe for target 'all' failed
make: *** [all] Error 2
```

## How has this been tested?
Tested in a clean VM.

```shell
readelf -s install/demo/bin/worker | grep fm
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update (this change is mainly a documentation update)

## Checklist:
- [x] My code passes format and lint checks.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have tested my code with a reasonable workload.
- [ ] My code may break some other features.
