### PR TITLE
Fix annotation of cudnnGetConvolutionForwardAlgorithm_v7

### DIFF
--- a/cava/samples/cudart/cudart.cpp
+++ b/cava/samples/cudart/cudart.cpp
@@ -1530,7 +1530,7 @@ cudnnGetConvolutionForwardAlgorithm_v7(cudnnHandle_t                       handl
         ava_out; ava_buffer(1);
     }
     ava_argument(perfResults) {
-        ava_out; ava_buffer(1);
+        ava_out; cu_in_out_buffer(requestedAlgoCount, returnedAlgoCount);
         ava_lifetime_manual;
     }
 }

--- a/cava/samples/onnxruntime/onnx_dump.cpp
+++ b/cava/samples/onnxruntime/onnx_dump.cpp
@@ -5597,7 +5597,7 @@ cudnnGetConvolutionForwardAlgorithm_v7(cudnnHandle_t                       handl
         ava_out; ava_buffer(1);
     }
     ava_argument(perfResults) {
-        ava_out; ava_buffer(1);
+        ava_out; cu_in_out_buffer(requestedAlgoCount, returnedAlgoCount);
     }
 }
 
@@ -6977,8 +6977,6 @@ cudnnFindConvolutionForwardAlgorithm(cudnnHandle_t handle,
     fprintf(stderr, "%s is not implemented\n", __func__);
     abort();
 }
-
-#define cu_in_out_buffer(x, y) ({ if(ava_is_in) ava_buffer(x); else ava_buffer(std::min(x, y == (void*)0 ? x : *y)); })
 
 cudnnStatus_t CUDNNWINAPI
 cudnnFindConvolutionForwardAlgorithmEx(cudnnHandle_t handle,

--- a/cava/samples/onnxruntime/onnx_opt.cpp
+++ b/cava/samples/onnxruntime/onnx_opt.cpp
@@ -6205,7 +6205,7 @@ cudnnGetConvolutionForwardAlgorithm_v7(cudnnHandle_t                       handl
         ava_out; ava_buffer(1);
     }
     ava_argument(perfResults) {
-        ava_out; ava_buffer(1);
+        ava_out; cu_in_out_buffer(requestedAlgoCount, returnedAlgoCount);
     }
 }
 
@@ -7593,8 +7593,6 @@ cudnnFindConvolutionForwardAlgorithm(cudnnHandle_t handle,
     fprintf(stderr, "%s is not implemented\n", __func__);
     abort();
 }
-
-#define cu_in_out_buffer(x, y) ({ if(ava_is_in) ava_buffer(x); else ava_buffer(std::min(x, y == (void*)0 ? x : *y)); })
 
 cudnnStatus_t CUDNNWINAPI
 cudnnFindConvolutionForwardAlgorithmEx(cudnnHandle_t handle,

--- a/cava/samples/pytorch/pt_dump.cpp
+++ b/cava/samples/pytorch/pt_dump.cpp
@@ -5657,7 +5657,7 @@ cudnnGetConvolutionForwardAlgorithm_v7(cudnnHandle_t                       handl
         ava_out; ava_buffer(1);
     }
     ava_argument(perfResults) {
-        ava_out; ava_buffer(1);
+        ava_out; cu_in_out_buffer(requestedAlgoCount, returnedAlgoCount);
     }
 }
 

--- a/cava/samples/pytorch/pt_opt.cpp
+++ b/cava/samples/pytorch/pt_opt.cpp
@@ -6229,7 +6229,7 @@ cudnnGetConvolutionForwardAlgorithm_v7(cudnnHandle_t                       handl
         ava_out; ava_buffer(1);
     }
     ava_argument(perfResults) {
-        ava_out; ava_buffer(1);
+        ava_out; cu_in_out_buffer(requestedAlgoCount, returnedAlgoCount);
     }
 }
 

--- a/cava/samples/tensorflow/tf_dump.cpp
+++ b/cava/samples/tensorflow/tf_dump.cpp
@@ -5640,7 +5640,7 @@ cudnnGetConvolutionForwardAlgorithm_v7(cudnnHandle_t                       handl
         ava_out; ava_buffer(1);
     }
     ava_argument(perfResults) {
-        ava_out; ava_buffer(1);
+        ava_out; cu_in_out_buffer(requestedAlgoCount, returnedAlgoCount);
     }
 }
 

--- a/cava/samples/tensorflow/tf_opt.cpp
+++ b/cava/samples/tensorflow/tf_opt.cpp
@@ -6230,7 +6230,7 @@ cudnnGetConvolutionForwardAlgorithm_v7(cudnnHandle_t                       handl
         ava_out; ava_buffer(1);
     }
     ava_argument(perfResults) {
-        ava_out; ava_buffer(1);
+        ava_out; cu_in_out_buffer(requestedAlgoCount, returnedAlgoCount);
     }
 }
 

--- a/common/extensions/cudart_10.1_utilities.cpp
+++ b/common/extensions/cudart_10.1_utilities.cpp
@@ -6,6 +6,13 @@
 
 #include <stdexcept>
 
+int deference_int_pointer(int *p) {
+  if (p)
+    return *p;
+  else
+    return 0;
+}
+
 size_t __helper_fatbin_size(const void *cubin) {
   struct fatBinaryHeader *fbh = (struct fatBinaryHeader *)cubin;
   return fbh->fatSize + fbh->headerSize;

--- a/common/extensions/cudart_10.1_utilities.hpp
+++ b/common/extensions/cudart_10.1_utilities.hpp
@@ -6,6 +6,8 @@
 #include <cuda_runtime_api.h>
 #include <glib.h>
 
+#include <algorithm>
+
 #define MAX_KERNEL_ARG 30
 #define MAX_KERNEL_NAME_LEN 1024
 #define MAX_ASYNC_BUFFER_NUM 16
@@ -13,6 +15,16 @@
 #if defined(__cplusplus)
 extern "C" {
 #endif /* __cplusplus */
+
+int deference_int_pointer(int *p);
+
+#define cu_in_out_buffer(x, y)                                                \
+  ({                                                                          \
+    if (ava_is_in)                                                            \
+      ava_buffer(x);                                                          \
+    else                                                                      \
+      ava_buffer(std::min(x, y == (void *)0 ? x : deference_int_pointer(y))); \
+  })
 
 struct fatbin_wrapper {
   uint32_t magic;


### PR DESCRIPTION
## Description
Previously, cudnnGetConvolutionForwardAlgorithm_v7 may crash at page fault.

## Motivation and Context
The previous annotation specify cudnnGetConvolutionForwardAlgorithm_v7 to return only one "cudnnConvolutionFwdAlgoPerf_t". But instead, it returns `requestedAlgoCount` or `*returnedAlgoCount` structs.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update (this change is mainly a documentation update)

## Checklist:
- [x] My code passes format and lint checks.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have tested my code with a reasonable workload.
- [ ] My code may break some other features.
