### PR TITLE
Allow ava config file to be in non-default path, by setting AVA_CONFIG_FILE_PATH. Docs fixed.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(ava)
 
 ###### Options ######
 
-set(CMAKE_BUILD_TYPE Release CACHE STRING "Build configuration (Relase/Debug)")
+set(CMAKE_BUILD_TYPE Release CACHE STRING "Build configuration (Release/Debug)")
 set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release")
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)

--- a/cava/samples/demo/test_program/Makefile
+++ b/cava/samples/demo/test_program/Makefile
@@ -1,5 +1,5 @@
 all:
 	gcc -o test test.c \
 		-I../../../headers \
-		-L../../../../../ava-build/install/demo/lib -ldemo 
+		-L../../../../../ava-build/install/demo/lib -ldemo \
 		-lprotobuf

--- a/cava/samples/demo/test_program/Makefile
+++ b/cava/samples/demo/test_program/Makefile
@@ -1,5 +1,5 @@
 all:
 	gcc -o test test.c \
 		-I../../../headers \
-		-L../../../../../ava-build/install/demo_nw/lib -ldemo \
+		-L../../../../../ava-build/install/demo/lib -ldemo 
 		-lprotobuf

--- a/config/README.md
+++ b/config/README.md
@@ -2,7 +2,9 @@ Configuration Files
 ===================
 
 Configuration files are replacing environment variables for AvA's settings.
-Guestlib reads `/etc/ava/guest.conf` for user-defined configurations.
+The guestlib reads `/etc/ava/guest.conf` by default for user-defined configurations,
+this can be changed by setting the environment variable `AVA_CONFIG_FILE_PATH`
+to the absolute path to a configuration file.
 
 Run `setup.sh` to install an example configuration.
 

--- a/docs/build_and_setup.md
+++ b/docs/build_and_setup.md
@@ -133,6 +133,10 @@ manager_address = "0.0.0.0:3333";
 gpu_memory = [1024L];
 EOF
 ```
+The guestlib assumes by default the configuration file is at `/etc/ava/guest.conf`,
+but any path can be used as long as the environment variable `AVA_CONFIG_FILE_PATH`
+is exported and contains the absolute path to the configuration file.
+
 
 Run the test program by
 

--- a/docs/build_and_setup.md
+++ b/docs/build_and_setup.md
@@ -98,7 +98,7 @@ make -j`nproc`
 make install
 ```
 
-This generates the guestlib and API server codes in `ava/cava/demo_nw` and
+This generates the guestlib and API server codes in `ava/cava/demo` and
 installs their binary files to `build/install/demo`. The demo manager is
 compiled and installed into `build/install/bin`.
 
@@ -108,7 +108,8 @@ ls install/demo/lib
 ls install/bin
 ```
 
-AvA's base repository includes a tiny standalone demo program.
+AvA's base repository includes a tiny standalone demo program. If compilation fails,
+make sure the Makefile has the correct path to the `build` folder.
 
 ```shell
 pushd .
@@ -120,7 +121,7 @@ popd
 Start the demo manager by
 
 ```shell
-./install/bin/demo_manager --worker_path install/demo_nw/bin/worker
+./install/bin/demo_manager --worker_path install/demo/bin/worker
 ```
 
 Add AvA configuration file:

--- a/docs/build_and_setup.md
+++ b/docs/build_and_setup.md
@@ -98,7 +98,7 @@ make -j`nproc`
 make install
 ```
 
-This generates the guestlib and API server codes in `ava/cava/demo` and
+This generates the guestlib and API server codes in `ava/cava/demo_nw` and
 installs their binary files to `build/install/demo`. The demo manager is
 compiled and installed into `build/install/bin`.
 

--- a/guestlib/guest_config.cpp
+++ b/guestlib/guest_config.cpp
@@ -6,13 +6,17 @@ namespace guestconfig {
 
 std::shared_ptr<GuestConfig> config;
 
+char* getConfigFilePath() {
+  return std::getenv("AVA_CONFIG_FILE_PATH") ? std::getenv("AVA_CONFIG_FILE_PATH") : (char*)kDefaultConfigFilePath;
+}
+
 std::shared_ptr<GuestConfig> readGuestConfig() {
   libconfig::Config cfg;
 
   try {
-    cfg.readFile(guestconfig::kConfigFilePath);
+    cfg.readFile(guestconfig::getConfigFilePath());
   } catch (const libconfig::FileIOException &fioex) {
-    std::cerr << "I/O error when reading " << guestconfig::kConfigFilePath << std::endl;
+    std::cerr << "I/O error when reading " << guestconfig::getConfigFilePath() << std::endl;
     return nullptr;
   } catch (const libconfig::ParseException &pex) {
     std::cerr << "Parse error at " << pex.getFile() << ":" << pex.getLine() << " - " << pex.getError() << std::endl;

--- a/guestlib/guest_config.cpp
+++ b/guestlib/guest_config.cpp
@@ -6,8 +6,8 @@ namespace guestconfig {
 
 std::shared_ptr<GuestConfig> config;
 
-char* getConfigFilePath() {
-  return std::getenv("AVA_CONFIG_FILE_PATH") ? std::getenv("AVA_CONFIG_FILE_PATH") : (char*)kDefaultConfigFilePath;
+char *getConfigFilePath() {
+  return std::getenv("AVA_CONFIG_FILE_PATH") ? std::getenv("AVA_CONFIG_FILE_PATH") : (char *)kDefaultConfigFilePath;
 }
 
 std::shared_ptr<GuestConfig> readGuestConfig() {

--- a/guestlib/guest_config.h
+++ b/guestlib/guest_config.h
@@ -11,7 +11,7 @@
 
 namespace guestconfig {
 
-constexpr char kConfigFilePath[] = "/etc/ava/guest.conf";
+constexpr char kDefaultConfigFilePath[] = "/etc/ava/guest.conf";
 constexpr char kDefaultChannel[] = "TCP";
 constexpr uint64_t kDefaultConnectTimeout = 5000;
 constexpr char kDefaultManagerAddress[] = "0.0.0.0:3334";
@@ -48,6 +48,9 @@ class GuestConfig {
   std::vector<uint64_t> gpu_memory_;
   plog::Severity logger_severity_;
 };
+
+
+char* getConfigFilePath();
 
 std::shared_ptr<GuestConfig> readGuestConfig();
 

--- a/guestlib/guest_config.h
+++ b/guestlib/guest_config.h
@@ -49,8 +49,7 @@ class GuestConfig {
   plog::Severity logger_severity_;
 };
 
-
-char* getConfigFilePath();
+char *getConfigFilePath();
 
 std::shared_ptr<GuestConfig> readGuestConfig();
 

--- a/guestlib/init.cpp
+++ b/guestlib/init.cpp
@@ -48,8 +48,8 @@ EXPORTED_WEAKLY void nw_init_guestlib(intptr_t api_id) {
     // } else if (guestconfig::config->channel_ == "VSOCK") {
     //   chan = command_channel_socket_new();
   } else {
-    std::cerr << "Unsupported channel specified in " << guestconfig::getConfigFilePath() << ", expect channel = [\"TCP\"]"
-              << std::endl;
+    std::cerr << "Unsupported channel specified in " << guestconfig::getConfigFilePath()
+              << ", expect channel = [\"TCP\"]" << std::endl;
     exit(0);
   }
   if (!chan) {

--- a/guestlib/init.cpp
+++ b/guestlib/init.cpp
@@ -48,7 +48,7 @@ EXPORTED_WEAKLY void nw_init_guestlib(intptr_t api_id) {
     // } else if (guestconfig::config->channel_ == "VSOCK") {
     //   chan = command_channel_socket_new();
   } else {
-    std::cerr << "Unsupported channel specified in " << guestconfig::kConfigFilePath << ", expect channel = [\"TCP\"]"
+    std::cerr << "Unsupported channel specified in " << guestconfig::getConfigFilePath() << ", expect channel = [\"TCP\"]"
               << std::endl;
     exit(0);
   }


### PR DESCRIPTION
## Description
Allow ava config file to be in non-default path, by setting AVA_CONFIG_FILE_PATH. Docs fixed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Document update (this change is mainly a documentation update)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code passes format and lint checks.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have tested my code with a reasonable workload.
- [ ] My code may break some other features.
