### PR TITLE
remove boost from guestlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,26 +100,6 @@ endif()
 ###### Dependent libraries ######
 include(ExternalProject)
 
-# boost
-set(BOOST_TARGET "boost_1_71_0")
-set(BOOST_VERSION "1.71.0")
-set(BOOST_URL
-  https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/${BOOST_TARGET}.tar.gz)
-add_library(boost INTERFACE)
-add_dependencies(boost ${BOOST_TARGET})
-ExternalProject_Add(
-  ${BOOST_TARGET}
-  CONFIGURE_COMMAND ""
-  BUILD_COMMAND ""
-  INSTALL_COMMAND ""
-  URL ${BOOST_URL}
-  SOURCE_DIR ${CMAKE_SOURCE_DIR}/third_party/${BOOST_TARGET}
-  DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/third_party/
-  BUILD_IN_SOURCE 1
-)
-target_include_directories(boost INTERFACE
-  ${CMAKE_SOURCE_DIR}/third_party/${BOOST_TARGET}/)
-
 # libconfig
 set(INSTALL_PREFIX ${CMAKE_SOURCE_DIR}/third_party/deps)
 ExternalProject_Add(config++_build

--- a/cava/nightwatch/generator/c/cmakelists.py
+++ b/cava/nightwatch/generator/c/cmakelists.py
@@ -101,7 +101,6 @@ add_library(${{SUBPROJECT_PREFIX}}_guestlib SHARED
 )
 target_link_libraries(${{SUBPROJECT_PREFIX}}_guestlib
   glib2.0
-  boost
   Threads::Threads
   fmt::fmt
   GSL

--- a/cava/nightwatch/generator/c/cmakelists.py
+++ b/cava/nightwatch/generator/c/cmakelists.py
@@ -72,6 +72,7 @@ target_link_libraries(${{SUBPROJECT_PREFIX}}_worker
   Threads::Threads
   fmt::fmt
   GSL
+  absl::strings
   {api.libs}
 )
 set_target_properties(${{SUBPROJECT_PREFIX}}_worker PROPERTIES OUTPUT_NAME "worker")
@@ -95,6 +96,7 @@ add_library(${{SUBPROJECT_PREFIX}}_guestlib SHARED
   ${{CMAKE_SOURCE_DIR}}/common/shadow_thread_pool.cpp
   ${{CMAKE_SOURCE_DIR}}/common/cmd_channel_socket_utilities.cpp
   ${{CMAKE_SOURCE_DIR}}/common/cmd_channel_socket_tcp.cpp
+  ${{CMAKE_SOURCE_DIR}}/common/support/socket.cpp
   ${{CMAKE_SOURCE_DIR}}/proto/manager_service.proto.cpp
 )
 target_link_libraries(${{SUBPROJECT_PREFIX}}_guestlib
@@ -104,6 +106,7 @@ target_link_libraries(${{SUBPROJECT_PREFIX}}_guestlib
   fmt::fmt
   GSL
   config++
+  absl::strings
 )
 target_compile_options(${{SUBPROJECT_PREFIX}}_guestlib
   PUBLIC -fvisibility=hidden

--- a/common/cmd_channel_socket_tcp.cpp
+++ b/common/cmd_channel_socket_tcp.cpp
@@ -10,8 +10,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include <boost/algorithm/string.hpp>
-#include <boost/asio.hpp>
 #include <chrono>
 #include <iostream>
 #include <string>
@@ -24,8 +22,6 @@
 #include "common/guest_mem.h"
 #include "common/logging.h"
 #include "manager_service.proto.h"
-
-using boost::asio::ip::tcp;
 
 extern int nw_global_vm_id;
 

--- a/common/std_span.h
+++ b/common/std_span.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <gsl/span>
+#include <gsl/span_ext>
+
+namespace std {
+using gsl::span;
+}  // namespace std
+
+#define EMPTY_CHAR_SPAN std::span<const char>()
+
+#define STRING_AS_SPAN(STR_VAR) std::span<const char>((STR_VAR).data(), (STR_VAR).length())
+
+#define VECTOR_AS_SPAN(VEC_VAR) std::span<const decltype(VEC_VAR)::value_type>((VEC_VAR).data(), (VEC_VAR).size())
+
+#define VECTOR_AS_CHAR_SPAN(VEC_VAR)                                      \
+  std::span<const char>(reinterpret_cast<const char *>((VEC_VAR).data()), \
+                        sizeof(decltype(VEC_VAR)::value_type) * (VEC_VAR).size())

--- a/common/support/fmt.h
+++ b/common/support/fmt.h
@@ -1,0 +1,24 @@
+#ifndef _AVA_SUPPORT_FMT_H_
+#define _AVA_SUPPORT_FMT_H_
+// adopt from envy
+
+#include <absl/strings/string_view.h>
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
+namespace fmt {
+
+// Provide an implementation of formatter for fmt::format that allows absl::string_view to be
+// formatted with the same format specifiers available to std::string.
+// NOLINTNEXTLINE(readability-identifier-naming)
+template <>
+struct formatter<absl::string_view> : formatter<string_view> {
+  auto format(absl::string_view absl_string_view, fmt::format_context &ctx) -> decltype(ctx.out()) {
+    string_view fmt_string_view(absl_string_view.data(), absl_string_view.size());
+    return formatter<string_view>::format(fmt_string_view, ctx);
+  }
+};
+
+}  // namespace fmt
+
+#endif // _AVA_SUPPORT_FMT_H_

--- a/common/support/fmt.h
+++ b/common/support/fmt.h
@@ -21,4 +21,4 @@ struct formatter<absl::string_view> : formatter<string_view> {
 
 }  // namespace fmt
 
-#endif // _AVA_SUPPORT_FMT_H_
+#endif  // _AVA_SUPPORT_FMT_H_

--- a/common/support/fmt.h
+++ b/common/support/fmt.h
@@ -1,5 +1,5 @@
-#ifndef _AVA_SUPPORT_FMT_H_
-#define _AVA_SUPPORT_FMT_H_
+#ifndef _AVA_COMMON_SUPPORT_FMT_H_
+#define _AVA_COMMON_SUPPORT_FMT_H_
 // adopt from envy
 
 #include <absl/strings/string_view.h>
@@ -21,4 +21,4 @@ struct formatter<absl::string_view> : formatter<string_view> {
 
 }  // namespace fmt
 
-#endif  // _AVA_SUPPORT_FMT_H_
+#endif  // _AVA_COMMON_SUPPORT_FMT_H_

--- a/common/support/io.h
+++ b/common/support/io.h
@@ -1,5 +1,5 @@
-#ifndef _AVA_SUPPORT_IO_H_
-#define _AVA_SUPPORT_IO_H_
+#ifndef _AVA_COMMON_SUPPORT_IO_H_
+#define _AVA_COMMON_SUPPORT_IO_H_
 #include <errno.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -13,7 +13,6 @@ inline bool SendData(int fd, const char *data, size_t size) {
   size_t pos = 0;
   while (pos < size) {
     ssize_t nwrite = write(fd, data + pos, size - pos);
-    // DCHECK(nwrite != 0) << "write() returns 0";
     if (nwrite < 0) {
       if (errno == EAGAIN || errno == EINTR) {
         continue;
@@ -60,4 +59,4 @@ inline bool RecvData(int fd, char *buffer, size_t size, bool *eof) {
 }  // namespace support
 }  // namespace ava
 
-#endif  // _AVA_SUPPORT_IO_H_
+#endif  // _AVA_COMMON_SUPPORT_IO_H_

--- a/common/support/io.h
+++ b/common/support/io.h
@@ -29,7 +29,7 @@ inline bool SendData(int fd, std::span<const char> data) { return SendData(fd, d
 
 inline bool WriteData(int fd, std::span<const char> data) { return SendData(fd, data.data(), data.size()); }
 
-inline bool WriteData(int fd, const char* data, size_t size) { return SendData(fd, data, size); }
+inline bool WriteData(int fd, const char *data, size_t size) { return SendData(fd, data, size); }
 
 inline bool WriteString(int fd, std::string data) { return SendData(fd, data.data(), data.size()); }
 
@@ -60,4 +60,4 @@ inline bool RecvData(int fd, char *buffer, size_t size, bool *eof) {
 }  // namespace support
 }  // namespace ava
 
-#endif // _AVA_SUPPORT_IO_H_
+#endif  // _AVA_SUPPORT_IO_H_

--- a/common/support/io.h
+++ b/common/support/io.h
@@ -1,0 +1,63 @@
+#ifndef _AVA_SUPPORT_IO_H_
+#define _AVA_SUPPORT_IO_H_
+#include <errno.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "std_span.h"
+
+namespace ava {
+namespace support {
+
+inline bool SendData(int fd, const char *data, size_t size) {
+  size_t pos = 0;
+  while (pos < size) {
+    ssize_t nwrite = write(fd, data + pos, size - pos);
+    // DCHECK(nwrite != 0) << "write() returns 0";
+    if (nwrite < 0) {
+      if (errno == EAGAIN || errno == EINTR) {
+        continue;
+      }
+      return false;
+    }
+    pos += static_cast<size_t>(nwrite);
+  }
+  return true;
+}
+
+inline bool SendData(int fd, std::span<const char> data) { return SendData(fd, data.data(), data.size()); }
+
+inline bool WriteData(int fd, std::span<const char> data) { return SendData(fd, data.data(), data.size()); }
+
+inline bool WriteData(int fd, const char* data, size_t size) { return SendData(fd, data, size); }
+
+inline bool WriteString(int fd, std::string data) { return SendData(fd, data.data(), data.size()); }
+
+inline bool RecvData(int fd, char *buffer, size_t size, bool *eof) {
+  size_t pos = 0;
+  if (eof != nullptr) {
+    *eof = false;
+  }
+  while (pos < size) {
+    ssize_t nread = read(fd, buffer + pos, size - pos);
+    if (nread == 0) {
+      if (eof != nullptr) {
+        *eof = true;
+      }
+      return false;
+    }
+    if (nread < 0) {
+      if (errno == EAGAIN || errno == EINTR) {
+        continue;
+      }
+      return false;
+    }
+    pos += static_cast<size_t>(nread);
+  }
+  return true;
+}
+
+}  // namespace support
+}  // namespace ava
+
+#endif // _AVA_SUPPORT_IO_H_

--- a/common/support/socket.cpp
+++ b/common/support/socket.cpp
@@ -1,86 +1,86 @@
+#include "socket.h"
+
+#include <absl/strings/numbers.h>
+#include <absl/strings/string_view.h>
 #include <arpa/inet.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <sys/ioctl.h>
-#include <sys/un.h>
+#include <errno.h>
+#include <fmt/format.h>
+#include <net/if.h>
+#include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
-#include <netdb.h>
-#include <net/if.h>
-#include <errno.h>
 #include <string.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/un.h>
 
-#include <string>
 #include <gsl/gsl>
-#include <absl/strings/string_view.h>
-#include <absl/strings/numbers.h>
-#include <fmt/format.h>
+#include <string>
+
 #include "common/logging.h"
-#include "socket.h"
 
 namespace ava {
 namespace support {
 
 namespace {
-static bool ResolveHostInternal(absl::string_view host_or_ip, struct in_addr* addr) {
-    // Assume host_or_ip is IP address first
-    if (inet_aton(std::string(host_or_ip).c_str(), addr) == 1) {
-        return true;
-    }
-    // Use getaddrinfo to resolve host
-    struct addrinfo hints;
-    memset(&hints, 0, sizeof(hints));
-    hints.ai_family = AF_INET;
-    hints.ai_socktype = SOCK_STREAM;
-    hints.ai_flags |= AI_CANONNAME;
-    struct addrinfo* result;
-    int ret = getaddrinfo(std::string(host_or_ip).c_str(), nullptr, &hints, &result);
-    if (ret != 0) {
-        if (ret != EAI_SYSTEM) {
-            AVA_LOG(ERROR) << "getaddrinfo with " << host_or_ip << " failed : " << gai_strerror(ret);
-        } else {
-            AVA_LOG(ERROR) << "getaddrinfo with " << host_or_ip << " failed";
-        }
-        return false;
-    }
-    auto free_freeaddrinfo_result = gsl::finally([result] () {
-        freeaddrinfo(result);
-    });
-    while (result) {
-        if (result->ai_family == AF_INET) {
-            struct sockaddr_in* resolved_addr = (struct sockaddr_in*)result->ai_addr;
-            *addr = resolved_addr->sin_addr;
-            return true;
-        }
-        result = result->ai_next;
+static bool ResolveHostInternal(absl::string_view host_or_ip, struct in_addr *addr) {
+  // Assume host_or_ip is IP address first
+  if (inet_aton(std::string(host_or_ip).c_str(), addr) == 1) {
+    return true;
+  }
+  // Use getaddrinfo to resolve host
+  struct addrinfo hints;
+  memset(&hints, 0, sizeof(hints));
+  hints.ai_family = AF_INET;
+  hints.ai_socktype = SOCK_STREAM;
+  hints.ai_flags |= AI_CANONNAME;
+  struct addrinfo *result;
+  int ret = getaddrinfo(std::string(host_or_ip).c_str(), nullptr, &hints, &result);
+  if (ret != 0) {
+    if (ret != EAI_SYSTEM) {
+      AVA_LOG(ERROR) << "getaddrinfo with " << host_or_ip << " failed : " << gai_strerror(ret);
+    } else {
+      AVA_LOG(ERROR) << "getaddrinfo with " << host_or_ip << " failed";
     }
     return false;
+  }
+  auto free_freeaddrinfo_result = gsl::finally([result]() { freeaddrinfo(result); });
+  while (result) {
+    if (result->ai_family == AF_INET) {
+      struct sockaddr_in *resolved_addr = (struct sockaddr_in *)result->ai_addr;
+      *addr = resolved_addr->sin_addr;
+      return true;
+    }
+    result = result->ai_next;
+  }
+  return false;
 }
-} // namespace
+}  // namespace
 
-int TcpSocketConnect(struct sockaddr_in* addr) {
+int TcpSocketConnect(struct sockaddr_in *addr) {
   int fd = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, 0);
   if (fd == -1) {
-      AVA_LOG(ERROR) << "Failed to create AF_INET socket";
-      return -1;
+    AVA_LOG(ERROR) << "Failed to create AF_INET socket";
+    return -1;
   }
-  if (connect(fd, (struct sockaddr*)addr, sizeof(struct sockaddr_in)) != 0) {
-      AVA_LOG(ERROR) << "Failed to connect: " << strerror(errno);
-      close(fd);
-      return -1;
+  if (connect(fd, (struct sockaddr *)addr, sizeof(struct sockaddr_in)) != 0) {
+    AVA_LOG(ERROR) << "Failed to connect: " << strerror(errno);
+    close(fd);
+    return -1;
   }
   return fd;
 }
 
-bool ResolveTcpAddr(struct sockaddr_in* addr, absl::string_view host, absl::string_view port) {
+bool ResolveTcpAddr(struct sockaddr_in *addr, absl::string_view host, absl::string_view port) {
   int parsed_port;
   if (!absl::SimpleAtoi(port, &parsed_port)) {
-      return false;
+    return false;
   }
   addr->sin_family = AF_INET;
   addr->sin_port = htons(gsl::narrow_cast<uint16_t>(parsed_port));
   return ResolveHostInternal(host, &addr->sin_addr);
 }
 
-} // namespace support
-} // namespace ava
+}  // namespace support
+}  // namespace ava

--- a/common/support/socket.cpp
+++ b/common/support/socket.cpp
@@ -1,0 +1,86 @@
+#include <arpa/inet.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <sys/un.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <netdb.h>
+#include <net/if.h>
+#include <errno.h>
+#include <string.h>
+
+#include <string>
+#include <gsl/gsl>
+#include <absl/strings/string_view.h>
+#include <absl/strings/numbers.h>
+#include <fmt/format.h>
+#include "common/logging.h"
+#include "socket.h"
+
+namespace ava {
+namespace support {
+
+namespace {
+static bool ResolveHostInternal(absl::string_view host_or_ip, struct in_addr* addr) {
+    // Assume host_or_ip is IP address first
+    if (inet_aton(std::string(host_or_ip).c_str(), addr) == 1) {
+        return true;
+    }
+    // Use getaddrinfo to resolve host
+    struct addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags |= AI_CANONNAME;
+    struct addrinfo* result;
+    int ret = getaddrinfo(std::string(host_or_ip).c_str(), nullptr, &hints, &result);
+    if (ret != 0) {
+        if (ret != EAI_SYSTEM) {
+            AVA_LOG(ERROR) << "getaddrinfo with " << host_or_ip << " failed : " << gai_strerror(ret);
+        } else {
+            AVA_LOG(ERROR) << "getaddrinfo with " << host_or_ip << " failed";
+        }
+        return false;
+    }
+    auto free_freeaddrinfo_result = gsl::finally([result] () {
+        freeaddrinfo(result);
+    });
+    while (result) {
+        if (result->ai_family == AF_INET) {
+            struct sockaddr_in* resolved_addr = (struct sockaddr_in*)result->ai_addr;
+            *addr = resolved_addr->sin_addr;
+            return true;
+        }
+        result = result->ai_next;
+    }
+    return false;
+}
+} // namespace
+
+int TcpSocketConnect(struct sockaddr_in* addr) {
+  int fd = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  if (fd == -1) {
+      AVA_LOG(ERROR) << "Failed to create AF_INET socket";
+      return -1;
+  }
+  if (connect(fd, (struct sockaddr*)addr, sizeof(struct sockaddr_in)) != 0) {
+      AVA_LOG(ERROR) << "Failed to connect: " << strerror(errno);
+      close(fd);
+      return -1;
+  }
+  return fd;
+}
+
+bool ResolveTcpAddr(struct sockaddr_in* addr, absl::string_view host, absl::string_view port) {
+  int parsed_port;
+  if (!absl::SimpleAtoi(port, &parsed_port)) {
+      return false;
+  }
+  addr->sin_family = AF_INET;
+  addr->sin_port = htons(gsl::narrow_cast<uint16_t>(parsed_port));
+  return ResolveHostInternal(host, &addr->sin_addr);
+}
+
+} // namespace support
+} // namespace ava

--- a/common/support/socket.h
+++ b/common/support/socket.h
@@ -1,5 +1,5 @@
-#ifndef _AVA_SUPPORT_SOCKET_H_
-#define _AVA_SUPPORT_SOCKET_H_
+#ifndef _AVA_COMMON_SUPPORT_SOCKET_H_
+#define _AVA_COMMON_SUPPORT_SOCKET_H_
 #include <absl/strings/string_view.h>
 #include <netinet/in.h>
 
@@ -13,4 +13,4 @@ bool ResolveTcpAddr(struct sockaddr_in *addr, absl::string_view host, absl::stri
 
 }  // namespace support
 }  // namespace ava
-#endif
+#endif  // _AVA_COMMON_SUPPORT_SOCKET_H_

--- a/common/support/socket.h
+++ b/common/support/socket.h
@@ -1,16 +1,16 @@
 #ifndef _AVA_SUPPORT_SOCKET_H_
 #define _AVA_SUPPORT_SOCKET_H_
-#include <netinet/in.h>
 #include <absl/strings/string_view.h>
+#include <netinet/in.h>
 
 namespace ava {
 namespace support {
 
 // Return sockfd on success, and return -1 on error
-int TcpSocketConnect(struct sockaddr_in* addr);
+int TcpSocketConnect(struct sockaddr_in *addr);
 
-bool ResolveTcpAddr(struct sockaddr_in* addr, absl::string_view host, absl::string_view port);
+bool ResolveTcpAddr(struct sockaddr_in *addr, absl::string_view host, absl::string_view port);
 
-} // namespace support
-} // namespace ava
+}  // namespace support
+}  // namespace ava
 #endif

--- a/common/support/socket.h
+++ b/common/support/socket.h
@@ -1,0 +1,16 @@
+#ifndef _AVA_SUPPORT_SOCKET_H_
+#define _AVA_SUPPORT_SOCKET_H_
+#include <netinet/in.h>
+#include <absl/strings/string_view.h>
+
+namespace ava {
+namespace support {
+
+// Return sockfd on success, and return -1 on error
+int TcpSocketConnect(struct sockaddr_in* addr);
+
+bool ResolveTcpAddr(struct sockaddr_in* addr, absl::string_view host, absl::string_view port);
+
+} // namespace support
+} // namespace ava
+#endif

--- a/common/support/std_span.h
+++ b/common/support/std_span.h
@@ -1,3 +1,5 @@
+#ifndef _AVA_COMMON_SUPPORT_STD_SPAN_H_
+#define _AVA_COMMON_SUPPORT_STD_SPAN_H_
 #pragma once
 
 #include <gsl/span>
@@ -16,3 +18,5 @@ using gsl::span;
 #define VECTOR_AS_CHAR_SPAN(VEC_VAR)                                      \
   std::span<const char>(reinterpret_cast<const char *>((VEC_VAR).data()), \
                         sizeof(decltype(VEC_VAR)::value_type) * (VEC_VAR).size())
+
+#endif  // _AVA_COMMON_SUPPORT_STD_SPAN_H_

--- a/worker/CMakeLists.txt
+++ b/worker/CMakeLists.txt
@@ -7,6 +7,27 @@ install(DIRECTORY DESTINATION ${CMAKE_INSTALL_PREFIX})
 # Common libraries
 find_package(Threads REQUIRED)
 
+# boost
+set(BOOST_TARGET "boost_1_71_0")
+set(BOOST_VERSION "1.71.0")
+set(BOOST_URL
+  https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/${BOOST_TARGET}.tar.gz)
+add_library(boost INTERFACE)
+add_dependencies(boost ${BOOST_TARGET})
+ExternalProject_Add(
+  ${BOOST_TARGET}
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  INSTALL_COMMAND ""
+  URL ${BOOST_URL}
+  URL_HASH SHA256=96b34f7468f26a141f6020efb813f1a2f3dfb9797ecf76a7d7cbd843cc95f5bd
+  SOURCE_DIR ${CMAKE_SOURCE_DIR}/third_party/${BOOST_TARGET}
+  DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/third_party/
+  BUILD_IN_SOURCE 1
+)
+target_include_directories(boost INTERFACE
+  ${CMAKE_SOURCE_DIR}/third_party/${BOOST_TARGET}/)
+
 ###### Configure compiler ######
 
 # generate compile_commands.json


### PR DESCRIPTION
so that it won't conflict with the application

Signed-off-by: Zhiting Zhu <zhitingz@cs.utexas.edu>

## Description
<!--- Describe your changes in detail. -->
Remove the boost dependency from guestlib. The exposed symbol would cause conflicts with the application. 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran, etc. -->
Tested with onnx face detection. 
## Screenshots (if appropriate):

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update (this change is mainly a documentation update)

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
- [x] My code passes format and lint checks.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [x] I have tested my code with a reasonable workload.
- [ ] My code **may break** some other features.
