### PR TITLE
Remove redefinition of global metadata_map

### DIFF
--- a/common/endpoint_lib.hpp
+++ b/common/endpoint_lib.hpp
@@ -216,9 +216,6 @@ struct ava_callback_user_data {
 
 //! The endpoint representation itself
 
-#define metadata_map nw_global_metadata_map
-#define metadata_map_mutex nw_global_metadata_map_mutex
-
 struct ava_shadow_buffer_pool {
   pthread_mutex_t mutex;
   GHashTable *buffers_by_id;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
The global `nw_global_metadata_map` was redefined as `metadata_map` which is unnecessary.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran, etc. -->
Tested with Rodinia CUDART benchmark.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update (this change is mainly a documentation update)

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
- [x] My code passes format and lint checks.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have tested my code with a reasonable workload.
- [ ] My code **may break** some other features.
