### PR TITLE
Annotate some cudaStream* and cudaRuntime* APIs in CUDART spec

### DIFF
--- a/cava/samples/cudart/cudart.cpp
+++ b/cava/samples/cudart/cudart.cpp
@@ -633,6 +633,89 @@ cudaEventSynchronize(cudaEvent_t event)
 }
 
 __host__ cudaError_t CUDARTAPI
+cudaStreamCreate(cudaStream_t *pStream) {
+    ava_argument(pStream) {
+        ava_out; ava_buffer(1);
+        ava_element ava_handle;
+    }
+}
+
+__host__ cudaError_t CUDARTAPI
+cudaStreamCreateWithFlags(cudaStream_t* pStream, unsigned int flags)
+{
+    ava_argument(pStream) {
+        ava_out; ava_buffer(1);
+        ava_element ava_handle;
+    }
+}
+
+__host__ cudaError_t CUDARTAPI
+cudaStreamCreateWithPriority(cudaStream_t* pStream, unsigned int flags, int priority)
+{
+    ava_argument(pStream) {
+        ava_out; ava_buffer(1);
+        ava_element ava_handle;
+    }
+}
+
+__host__ cudaError_t CUDARTAPI
+cudaStreamDestroy(cudaStream_t stream)
+{
+    ava_argument(stream) {
+        ava_element ava_handle;
+    }
+}
+
+__host__ cudaError_t CUDARTAPI
+cudaStreamGetFlags(cudaStream_t hStream, unsigned int* flags)
+{
+    ava_argument(hStream) {
+        ava_handle;
+    }
+    ava_argument(flags) {
+        ava_out; ava_buffer(1);
+    }
+}
+
+__host__ cudaError_t CUDARTAPI
+cudaStreamGetPriority(cudaStream_t hStream, int* priority)
+{
+    ava_argument(hStream) {
+        ava_handle;
+    }
+    ava_argument(priority) {
+        ava_out; ava_buffer(1);
+    }
+}
+
+__host__ cudaError_t CUDARTAPI
+cudaStreamQuery(cudaStream_t stream)
+{
+    ava_argument(stream) {
+        ava_handle;
+    }
+}
+
+__host__ cudaError_t CUDARTAPI
+cudaStreamSynchronize(cudaStream_t stream)
+{
+    ava_argument(stream) {
+        ava_handle;
+    }
+}
+
+__host__ cudaError_t CUDARTAPI
+cudaStreamWaitEvent(cudaStream_t stream, cudaEvent_t event, unsigned int flags)
+{
+    ava_argument(stream) {
+        ava_handle;
+    }
+    ava_argument(event) {
+        ava_handle;
+    }
+}
+
+__host__ cudaError_t CUDARTAPI
 cudaStreamAddCallback(cudaStream_t AVA_UNUSED(stream),
         cudaStreamCallback_t AVA_UNUSED(callback),
         void * AVA_UNUSED(userData), unsigned int AVA_UNUSED(flags))

--- a/cava/samples/cudart/cudart.cpp
+++ b/cava/samples/cudart/cudart.cpp
@@ -674,6 +674,13 @@ cudaMemGetInfo(size_t *_free, size_t *total)
     }
 }
 
+__host__ cudaError_t CUDARTAPI
+cudaRuntimeGetVersion(int *version)
+{
+    ava_argument(version) {
+        ava_out; ava_buffer(1);
+    }
+}
 /* CUDA driver API */
 
 CUresult CUDAAPI


### PR DESCRIPTION
## Description
Add some cudaStream* and cudaRuntimeGetVersion APIs

## How has this been tested?
compiled cudart spec

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update (this change is mainly a documentation update)

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
- [ ] My code passes format and lint checks.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have tested my code with a reasonable workload.
- [ ] My code **may break** some other features.
