### PR TITLE
Always generate C++ files for C and C++ specs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -69,8 +69,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
           -DAVA_MANAGER_DEMO=ON \
           -DAVA_MANAGER_LEGACY=ON \
-          -DAVA_GEN_DEMO_SPEC=ON \
-          -DAVA_GEN_TEST_SPEC=ON
+          -DAVA_GEN_DEMO_SPEC=ON
 
     - name: Build
       run: |

--- a/.github/workflows/build_and_test_cuda.yml
+++ b/.github/workflows/build_and_test_cuda.yml
@@ -78,7 +78,7 @@ jobs:
     - name: Download ava-llvm and generate codes
       if: startsWith(matrix.os, 'ubuntu-')
       run: |
-        python3 generate.py -f -s cudadrv cudart
+        python3 generate.py -f -s cudadrv cudart tf_dump tf_opt onnx_dump onnx_opt
 
     ###
     # Standard CMake build process
@@ -88,7 +88,11 @@ jobs:
         cmake -S . -B $HOME/build \
           -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
           -DAVA_GEN_CUDADRV_SPEC=ON \
-          -DAVA_GEN_CUDART_SPEC=ON
+          -DAVA_GEN_CUDART_SPEC=ON \
+          -DAVA_GEN_TENSORFLOW_DUMP_SPEC=ON \
+          -DAVA_GEN_TENSORFLOW_OPT_SPEC=ON \
+          -DAVA_GEN_ONNXRT_DUMP_SPEC=ON \
+          -DAVA_GEN_ONNXRT_OPT_SPEC=ON
 
     - name: Build
       run: |

--- a/cava/nightwatch/generator/c/cmakelists.py
+++ b/cava/nightwatch/generator/c/cmakelists.py
@@ -32,7 +32,7 @@ set(CMAKE_CXX_EXTENSIONS OFF) #...without compiler extensions like gnu++11
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 set(c_flags {api.cflags})
-set(cxx_flags {api.cxxflags})
+set(cxx_flags {api.cflags} {api.cxxflags})
 add_compile_options("$<$<COMPILE_LANGUAGE:C>:${{c_flags}}>")
 add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:${{cxx_flags}}>")
 add_compile_options(-Wall -Wextra -pedantic -D_FILE_OFFSET_BITS=64 -fPIC -rdynamic -fpermissive -Wno-unused-parameter)

--- a/cava/nightwatch/generator/c/command_handler.py
+++ b/cava/nightwatch/generator/c/command_handler.py
@@ -70,9 +70,9 @@ void __print_command_{api.identifier.lower()}(FILE* file, const struct command_c
                                     const struct command_base* __cmd);
 
 #define ava_metadata(p) (&((struct {api.metadata_struct_spelling}*)ava_internal_metadata(&__ava_endpoint, p))->application)
-#define ava_zerocopy_alloc(s) ava_endpoint_zerocopy_alloc(&__ava_endpoint, s)
-#define ava_zerocopy_free(p) ava_endpoint_zerocopy_free(&__ava_endpoint, p)
-#define ava_zerocopy_get_physical_address(p) ava_endpoint_zerocopy_get_physical_address(&__ava_endpoint, p)
+// #define ava_zerocopy_alloc(s) ava_endpoint_zerocopy_alloc(&__ava_endpoint, s)
+// #define ava_zerocopy_free(p) ava_endpoint_zerocopy_free(&__ava_endpoint, p)
+// #define ava_zerocopy_get_physical_address(p) ava_endpoint_zerocopy_get_physical_address(&__ava_endpoint, p)
 
 
 #include "{api.c_utilities_header_spelling}"

--- a/cava/nightwatch/generator/common.py
+++ b/cava/nightwatch/generator/common.py
@@ -121,9 +121,8 @@ class _APISpelling:
 
     @property
     def source_extension(self) -> str:
-        if self.cplusplus:
-            return "cpp"
-        return "c"
+        # Always generate C++ files no matter whether self.cplusplus is True.
+        return "cpp"
 
     @property
     def c_header_spelling(self) -> str:

--- a/cava/nightwatch/main.py
+++ b/cava/nightwatch/main.py
@@ -61,7 +61,7 @@ def main():
     if not args.language:
         if args.inputfile.endswith(".py"):
             args.language = "py"
-        elif args.inputfile.endswith(".c"):
+        elif args.inputfile.endswith(".c") or args.inputfile.endswith(".cpp"):
             args.language = "c"
         else:
             args.language = "c"

--- a/cava/samples/test/libtrivial.c
+++ b/cava/samples/test/libtrivial.c
@@ -61,7 +61,7 @@ function1()
 //! Callbacks
 
 ava_callback_decl
-int error_callback(int errno, void *arg) {
+int error_callback(int errno_, void *arg) {
     ava_argument(arg) {
         ava_userdata;
     }
@@ -488,11 +488,13 @@ ava_begin_replacement;
 void *special_alloc(size_t size)
 {
     return ava_zerocopy_alloc(size);
+    return malloc(size);
 }
 
 void special_free(void *ptr)
 {
     ava_zerocopy_free(ptr);
+    return free(ptr);
 }
 ava_end_replacement;
 

--- a/cava/samples/test/libtrivial.c
+++ b/cava/samples/test/libtrivial.c
@@ -9,11 +9,11 @@ ava_soname(libtrivial.so);
 
 #include "libtrivial.h"
 
-//ava_begin_utility;
-//#ifndef __CAVA__
-//#include "common/zcopy.h"
-//#endif
-//ava_end_utility;
+ava_begin_utility;
+#ifndef __CAVA__
+#include "common/zcopy.h"
+#endif
+ava_end_utility;
 
 
 struct metadata_t {
@@ -488,13 +488,11 @@ ava_begin_replacement;
 void *special_alloc(size_t size)
 {
     return ava_zerocopy_alloc(size);
-    return malloc(size);
 }
 
 void special_free(void *ptr)
 {
     ava_zerocopy_free(ptr);
-    return free(ptr);
 }
 ava_end_replacement;
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
We have integrated lots of C++ features in AvA, but it's inflexible to wrap all those features in C APIs for C specs. In this purpose, we decide to always generate C++ files for both C and C++ specs.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran, etc. -->
Tested with cudadrv spec.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update (this change is mainly a documentation update)

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
- [x] My code passes format and lint checks.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have tested my code with a reasonable workload.
- [ ] My code **may break** some other features.
