### PR TITLE
Fix PyTorch fatbinary dumping

### DIFF
--- a/cava/samples/pytorch/pt_dump.cpp
+++ b/cava/samples/pytorch/pt_dump.cpp
@@ -281,7 +281,7 @@ ava_utility void __helper_dump_fatbin(void *fatCubin,
 
     while (fgets(line, sizeof(line), fp_pipe) != NULL) {
         /* Search functions */
-        if (strncmp(line, ".nv.info._Z", 11) == 0) {
+        if (strncmp(line, ".nv.info.", 9) == 0) {
             sprintf(name, line + 9, strlen(line) - 10);
             assert(strlen(line) - 10 < MAX_KERNEL_NAME_LEN);
             name[strlen(line) - 10] = '\0';

--- a/cava/samples/pytorch/pt_dump.cpp
+++ b/cava/samples/pytorch/pt_dump.cpp
@@ -178,39 +178,6 @@ ava_utility void __helper_dump_fatbin(void *fatCubin,
     struct fatBinaryHeader *fbh = reinterpret_cast<struct fatBinaryHeader *>(wp->ptr);
     int fd, ret;
 
-    /* Increase fatbin counter */
-    static int fatbin_num = 0;
-    fatbin_num++;
-    if (ava_is_worker) {
-        char* file_name = "/tmp/fatbin-info.ava";
-        fd = open(file_name, O_RDWR | O_CREAT, 0666);
-        if (fd == -1) {
-            fprintf(stderr, "open %s [errno=%d, errstr=%s] at %s:%d",
-                file_name, errno, strerror(errno), __FILE__, __LINE__);
-            exit(EXIT_FAILURE);
-        }
-        AVA_DEBUG << "Fatbinary counter = " << fatbin_num;
-        ret = write(fd, (const void *)&fatbin_num, sizeof(int));
-        if (ret == -1) {
-            fprintf(stderr, "write [errno=%d, errstr=%s] at %s:%d",
-                errno, strerror(errno), __FILE__, __LINE__);
-            exit(EXIT_FAILURE);
-        }
-        ret = lseek(fd, 0, SEEK_END);
-        if (ret == -1) {
-            fprintf(stderr, "lseek [errno=%d, errstr=%s] at %s:%d",
-                errno, strerror(errno), __FILE__, __LINE__);
-            exit(EXIT_FAILURE);
-        }
-        ret = write(fd, (const void *)wp, sizeof(struct fatbin_wrapper));
-        if (ret == -1) {
-            fprintf(stderr, "write [errno=%d, errstr=%s] at %s:%d",
-                errno, strerror(errno), __FILE__, __LINE__);
-            exit(EXIT_FAILURE);
-        }
-        close(fd);
-    }
-
     /* Dump fat binary to a file */
     char fatbin_filename[32];
     if (ava_is_worker) {
@@ -245,19 +212,6 @@ ava_utility void __helper_dump_fatbin(void *fatCubin,
         *num_funcs = 0;
     }
 
-    /* Add separator to the functions of different fatbinaries */
-    if (ava_is_worker) {
-        if (ava_metadata(NULL)->fd_functions != 0) {
-            size = 0;
-            ret = write(ava_metadata(NULL)->fd_functions, (const void *)&size, sizeof(size_t));
-            if (ret == -1) {
-                fprintf(stderr, "write [errno=%d, errstr=%s] at %s:%d",
-                    errno, strerror(errno), __FILE__, __LINE__);
-                exit(EXIT_FAILURE);
-            }
-        }
-    }
-
     /*  Open the command pipe for reading */
     char pip_command[80];
     sprintf(pip_command, "/usr/local/cuda-10.1/bin/cuobjdump -elf /tmp/fatbin-%d.ava",
@@ -267,17 +221,7 @@ ava_utility void __helper_dump_fatbin(void *fatCubin,
 
     /* Open function argument dump file */
     int function_arg_fd;
-    char function_arg_filename[32];
-    if (ava_is_worker) {
-        sprintf(function_arg_filename, "/tmp/function_arg-%d.ava", ava_metadata(NULL)->num_fatbins);
-        function_arg_fd = open(function_arg_filename, O_WRONLY | O_TRUNC | O_CREAT, 0666);
-        if (function_arg_fd == -1) {
-            fprintf(stderr, "open %s [errno=%d, errstr=%s] at %s:%d",
-                function_arg_filename, errno, strerror(errno), __FILE__, __LINE__);
-            exit(EXIT_FAILURE);
-        }
-        AVA_DEBUG << "Dump function argument info to " << function_arg_filename;
-    }
+    bool has_funcs = FALSE;
 
     while (fgets(line, sizeof(line), fp_pipe) != NULL) {
         /* Search functions */
@@ -285,7 +229,12 @@ ava_utility void __helper_dump_fatbin(void *fatCubin,
             sprintf(name, line + 9, strlen(line) - 10);
             assert(strlen(line) - 10 < MAX_KERNEL_NAME_LEN);
             name[strlen(line) - 10] = '\0';
-            ava_debug("[%d] %s@", *num_funcs, name);
+
+            // Skip duplicate function entries for multiple compute versions
+            if (g_hash_table_lookup(*fatbin_funcs, name) != NULL)
+              continue;
+
+            DEBUG_PRINT("[%d] %s@\n", *num_funcs, name);
 
             /* Create a new hash table entry */
             func = (struct fatbin_function *)g_malloc(sizeof(struct fatbin_function));
@@ -349,6 +298,20 @@ ava_utility void __helper_dump_fatbin(void *fatCubin,
 
             /* Dump the function argument sizes to file */
             if (ava_is_worker) {
+                /* Open function argument dump file on first valid function */
+                if (!has_funcs) {
+                    char function_arg_filename[32];
+
+                    sprintf(function_arg_filename, "/tmp/function_arg-%d.ava", ava_metadata(NULL)->num_fatbins);
+                    function_arg_fd = open(function_arg_filename, O_WRONLY | O_TRUNC | O_CREAT, 0666);
+                    if (function_arg_fd == -1) {
+                        fprintf(stderr, "open %s [errno=%d, errstr=%s] at %s:%d",
+                            function_arg_filename, errno, strerror(errno), __FILE__, __LINE__);
+                        exit(EXIT_FAILURE);
+                    }
+                    AVA_DEBUG << "Dump function argument info to " << function_arg_filename;
+                }
+
                 size = strlen(name) + 1;
                 ret = write(function_arg_fd, (void *)&size, sizeof(size_t));
                 if (ret == -1) {
@@ -370,20 +333,65 @@ ava_utility void __helper_dump_fatbin(void *fatCubin,
                 }
             }
 
+            has_funcs = TRUE;
+
             /* Insert the function into hash table */
-            if (g_hash_table_lookup(*fatbin_funcs, name) != NULL)
-                g_free(func);
-            else
-                g_hash_table_insert((*fatbin_funcs), g_strdup(name), (gpointer)func);
-            //func = (struct fatbin_function *)g_hash_table_lookup(*fatbin_funcs, name);
+            g_hash_table_insert((*fatbin_funcs), g_strdup(name), (gpointer)func);
         }
     }
 
+    if (has_funcs)
+        ++(ava_metadata(NULL)->num_fatbins);
+
+    // Were there any valid functions in the binary?
     if (ava_is_worker)
-        close(function_arg_fd);
+    {
+        if (has_funcs)
+        {
+            close(function_arg_fd);
+
+            char* file_name = "/tmp/fatbin-info.ava";
+            fd = open(file_name, O_RDWR | O_CREAT, 0666);
+            if (fd == -1) {
+                fprintf(stderr, "open %s [errno=%d, errstr=%s] at %s:%d",
+                    file_name, errno, strerror(errno), __FILE__, __LINE__);
+                exit(EXIT_FAILURE);
+            }
+            DEBUG_PRINT("Fatbinary counter = %d\n", ava_metadata(NULL)->num_fatbins);
+            ret = write(fd, (const void *)&(ava_metadata(NULL)->num_fatbins), sizeof(int));
+            if (ret == -1) {
+                fprintf(stderr, "write [errno=%d, errstr=%s] at %s:%d",
+                    errno, strerror(errno), __FILE__, __LINE__);
+                exit(EXIT_FAILURE);
+            }
+            ret = lseek(fd, 0, SEEK_END);
+            if (ret == -1) {
+                fprintf(stderr, "lseek [errno=%d, errstr=%s] at %s:%d",
+                    errno, strerror(errno), __FILE__, __LINE__);
+                exit(EXIT_FAILURE);
+            }
+            ret = write(fd, (const void *)wp, sizeof(struct fatbin_wrapper));
+            if (ret == -1) {
+                fprintf(stderr, "write [errno=%d, errstr=%s] at %s:%d",
+                    errno, strerror(errno), __FILE__, __LINE__);
+                exit(EXIT_FAILURE);
+            }
+            close(fd);
+
+            /* Add separator to the functions of different fatbinaries */
+            if (ava_metadata(NULL)->fd_functions != 0) {
+                size = 0;
+                ret = write(ava_metadata(NULL)->fd_functions, (const void *)&size, sizeof(size_t));
+                if (ret == -1) {
+                    fprintf(stderr, "write [errno=%d, errstr=%s] at %s:%d",
+                        errno, strerror(errno), __FILE__, __LINE__);
+                    exit(EXIT_FAILURE);
+                }
+            }
+        }
+    }
 
     pclose(fp_pipe);
-    ++(ava_metadata(NULL)->num_fatbins);
 }
 
 ava_utility void __helper_init_module(struct fatbin_wrapper *fatCubin, void **handle) {

--- a/cava/samples/pytorch/pt_opt.cpp
+++ b/cava/samples/pytorch/pt_opt.cpp
@@ -348,7 +348,7 @@ ava_utility CUmodule __helper_init_module(struct fatbin_wrapper *fatCubin, void 
     return mod;
 }
 
-ava_utility void __helper_load_function_arg_info_guest(void)
+ava_utility void __helper_load_function_arg_info(void)
 {
     GPtrArray *fatbin_funcs;
     GHashTable *ht;
@@ -402,7 +402,8 @@ ava_utility void __helper_load_function_arg_info_guest(void)
                 errno, strerror(errno), __FILE__, __LINE__);
             exit(EXIT_FAILURE);
         }
-        ava_debug("function %d (%s) has argc = %d",
+
+        DEBUG_PRINT("function %d (%s) has argc = %d\n",
                     fatbin_funcs->len - 1, func_name, func->argc);
         /* Insert into the function table */
         g_ptr_array_add(fatbin_funcs, (gpointer)func);
@@ -416,76 +417,6 @@ ava_utility void __helper_load_function_arg_info_guest(void)
     close(fd);
 
     ++(ava_metadata(NULL)->num_fatbins);
-}
-
-/**
- * Loads the function argument information from dump.
- */
-ava_utility GHashTable *__helper_load_function_arg_info(void) {
-    GPtrArray *fatbin_funcs;
-    if (ava_metadata(NULL)->fatbin_funcs == NULL) {
-        ava_metadata(NULL)->fatbin_funcs = g_ptr_array_new_with_free_func(g_free);
-        g_ptr_array_add(ava_metadata(NULL)->fatbin_funcs, (gpointer)NULL); // func_id starts from 1
-    }
-    fatbin_funcs = ava_metadata(NULL)->fatbin_funcs;
-
-    GHashTable *ht = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
-
-    int fd, read_ret;
-    char filename[50];
-    sprintf(filename, "/cuda_dumps/function_arg-%d.ava", ava_metadata(NULL)->num_fatbins);
-    AVA_DEBUG << "Loading " << filename;
-    fd = open(filename, O_RDONLY, 0666);
-    if (fd == -1) {
-        fprintf(stderr, "open [errno=%d, errstr=%s] at %s:%d",
-            errno, strerror(errno), __FILE__, __LINE__);
-        exit(EXIT_FAILURE);
-    }
-
-    struct fatbin_function *func;
-    size_t name_size;
-    char func_name[MAX_KERNEL_NAME_LEN];
-
-    while (1) {
-        read_ret = read(fd, (void *)&name_size, sizeof(size_t));
-        if (read_ret == 0)
-            break;
-        if (read_ret == -1) {
-            fprintf(stderr, "read [errno=%d, errstr=%s] at %s:%d",
-                errno, strerror(errno), __FILE__, __LINE__);
-            exit(EXIT_FAILURE);
-        }
-        assert(name_size < MAX_KERNEL_NAME_LEN && "name_size >= MAX_KERNEL_NAME_LEN");
-        read_ret = read(fd, (void *)func_name, name_size);
-        if (read_ret == -1) {
-            fprintf(stderr, "read [errno=%d, errstr=%s] at %s:%d",
-                errno, strerror(errno), __FILE__, __LINE__);
-            exit(EXIT_FAILURE);
-        }
-
-        func = g_new(struct fatbin_function, 1);
-        read_ret = read(fd, (void *)func, sizeof(struct fatbin_function));
-        if (read_ret == -1) {
-            fprintf(stderr, "read [errno=%d, errstr=%s] at %s:%d",
-                errno, strerror(errno), __FILE__, __LINE__);
-            exit(EXIT_FAILURE);
-        }
-
-        ava_debug("function %d (%s) has argc = %d",
-                    fatbin_funcs->len - 1, func_name, func->argc);
-        /* Insert into the function table */
-        g_ptr_array_add(fatbin_funcs, (gpointer)func);
-
-        /* Add name->index mapping */
-        if (g_hash_table_lookup(ht, func_name) == NULL) {
-            assert(fatbin_funcs->len > 1 && "fatbin_funcs->len <= 1");
-            g_hash_table_insert(ht, g_strdup(func_name), (gpointer)((uintptr_t)fatbin_funcs->len - 1));
-        }
-    }
-    close(fd);
-
-    ++(ava_metadata(NULL)->num_fatbins);
-    return ht;
 }
 
 /**
@@ -545,7 +476,8 @@ ava_utility void **__helper_load_and_register_fatbin(void *fatCubin) {
     CUmodule mod = __helper_init_module(wrapper, fatbin_handle);
 
     /* Load function argument information */
-    GHashTable *ht = __helper_load_function_arg_info();
+    __helper_load_function_arg_info ();
+    GHashTable *ht = ava_metadata(NULL)->ht_name2idx;
 
     /* Register CUDA functions */
     GPtrArray *fatbin_funcs = ava_metadata(NULL)->fatbin_funcs;
@@ -746,7 +678,6 @@ ava_utility void **__helper_load_and_register_fatbin(void *fatCubin) {
         if (wSize) free(wSize);
     }
 
-    g_hash_table_destroy(ht);
     return fatbin_handle;
 }
 
@@ -22889,7 +22820,7 @@ ava_utility void __helper_guestlib_init_prologue() {
     int i;
     ava_metadata(NULL)->num_fatbins = 0;
     for (i = 0; i < fatbin_num; i++) {
-        __helper_load_function_arg_info_guest();
+        __helper_load_function_arg_info();
     }
 #endif
     guestlib_tf_opt_init();


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
The previous dump spec failed to dump fatbinaries with no kernel or no useful kernel. This diff handles this corner case.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update (this change is mainly a documentation update)

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
- [x] My code passes format and lint checks.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have tested my code with a reasonable workload.
- [ ] My code **may break** some other features.
