### PR TITLE
Remove redundant print for unsupported APIs

### DIFF
--- a/cava/samples/onnxruntime/onnx_dump.cpp
+++ b/cava/samples/onnxruntime/onnx_dump.cpp
@@ -5534,7 +5534,6 @@ cudnnSetRNNDescriptor(cudnnHandle_t handle,
                       cudnnRNNAlgo_t algo,
                       cudnnDataType_t mathPrec)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5550,21 +5549,18 @@ cudnnGetRNNDescriptor(cudnnHandle_t handle,
                       cudnnRNNAlgo_t *algo,
                       cudnnDataType_t *mathPrec)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnSetRNNMatrixMathType(cudnnRNNDescriptor_t rnnDesc, cudnnMathType_t mType)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNMatrixMathType(cudnnRNNDescriptor_t rnnDesc, cudnnMathType_t *mType)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5576,7 +5572,6 @@ cudnnRNNSetClip(cudnnHandle_t handle,
                 double lclip,
                 double rclip)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5588,7 +5583,6 @@ cudnnRNNGetClip(cudnnHandle_t handle,
                 double *lclip,
                 double *rclip)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5598,7 +5592,6 @@ cudnnSetRNNProjectionLayers(cudnnHandle_t handle,
                             const int recProjSize,
                             const int outProjSize)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5608,7 +5601,6 @@ cudnnGetRNNProjectionLayers(cudnnHandle_t handle,
                             int *recProjSize,
                             int *outProjSize)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5619,21 +5611,18 @@ cudnnCreatePersistentRNNPlan(cudnnRNNDescriptor_t rnnDesc,
                              const cudnnDataType_t dataType,
                              cudnnPersistentRNNPlan_t *plan)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnDestroyPersistentRNNPlan(cudnnPersistentRNNPlan_t plan)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnSetPersistentRNNPlan(cudnnRNNDescriptor_t rnnDesc, cudnnPersistentRNNPlan_t plan)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5645,7 +5634,6 @@ cudnnGetRNNWorkspaceSize(cudnnHandle_t handle,
                          const cudnnTensorDescriptor_t *xDesc,
                          size_t *sizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5656,7 +5644,6 @@ cudnnGetRNNTrainingReserveSize(cudnnHandle_t handle,
                                const cudnnTensorDescriptor_t *xDesc,
                                size_t *sizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5667,7 +5654,6 @@ cudnnGetRNNParamsSize(cudnnHandle_t handle,
                       size_t *sizeInBytes,
                       cudnnDataType_t dataType)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5682,7 +5668,6 @@ cudnnGetRNNLinLayerMatrixParams(cudnnHandle_t handle,
                                 cudnnFilterDescriptor_t linLayerMatDesc,
                                 void **linLayerMat)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5697,7 +5682,6 @@ cudnnGetRNNLinLayerBiasParams(cudnnHandle_t handle,
                               cudnnFilterDescriptor_t linLayerBiasDesc,
                               void **linLayerBias)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5722,7 +5706,6 @@ cudnnRNNForwardInference(cudnnHandle_t handle,
                          void *workspace,
                          size_t workSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5749,7 +5732,6 @@ cudnnRNNForwardTraining(cudnnHandle_t handle,
                         void *reserveSpace,
                         size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5782,7 +5764,6 @@ cudnnRNNBackwardData(cudnnHandle_t handle,
                      void *reserveSpace,
                      size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5803,7 +5784,6 @@ cudnnRNNBackwardWeights(cudnnHandle_t handle,
                         const void *reserveSpace,
                         size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5812,28 +5792,24 @@ cudnnRNNBackwardWeights(cudnnHandle_t handle,
 cudnnStatus_t CUDNNWINAPI
 cudnnSetRNNPaddingMode(cudnnRNNDescriptor_t rnnDesc, cudnnRNNPaddingMode_t paddingMode)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNPaddingMode(cudnnRNNDescriptor_t rnnDesc, cudnnRNNPaddingMode_t *paddingMode)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnCreateRNNDataDescriptor(cudnnRNNDataDescriptor_t *rnnDataDesc)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnDestroyRNNDataDescriptor(cudnnRNNDataDescriptor_t rnnDataDesc)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5847,7 +5823,6 @@ cudnnSetRNNDataDescriptor(cudnnRNNDataDescriptor_t rnnDataDesc,
                           const int seqLengthArray[], /* length of each sequence in the batch */
                           void *paddingFill)          /* symbol for filling padding position in output */
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5862,7 +5837,6 @@ cudnnGetRNNDataDescriptor(cudnnRNNDataDescriptor_t rnnDataDesc,
                           int seqLengthArray[],
                           void *paddingFill)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5896,7 +5870,6 @@ cudnnRNNForwardTrainingEx(cudnnHandle_t handle,
                           void *reserveSpace,
                           size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5928,7 +5901,6 @@ cudnnRNNForwardInferenceEx(cudnnHandle_t handle,
                            void *workSpace,
                            size_t workSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5964,7 +5936,6 @@ cudnnRNNBackwardDataEx(cudnnHandle_t handle,
                        void *reserveSpace,
                        size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5984,7 +5955,6 @@ cudnnRNNBackwardWeightsEx(cudnnHandle_t handle,
                           void *reserveSpace,
                           size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5993,14 +5963,12 @@ cudnnRNNBackwardWeightsEx(cudnnHandle_t handle,
 cudnnStatus_t CUDNNWINAPI
 cudnnSetRNNAlgorithmDescriptor(cudnnHandle_t handle, cudnnRNNDescriptor_t rnnDesc, cudnnAlgorithmDescriptor_t algoDesc)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNForwardInferenceAlgorithmMaxCount(cudnnHandle_t handle, const cudnnRNNDescriptor_t rnnDesc, int *count)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6029,14 +5997,12 @@ cudnnFindRNNForwardInferenceAlgorithmEx(cudnnHandle_t handle,
                                         void *workspace,
                                         size_t workSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNForwardTrainingAlgorithmMaxCount(cudnnHandle_t handle, const cudnnRNNDescriptor_t rnnDesc, int *count)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6067,14 +6033,12 @@ cudnnFindRNNForwardTrainingAlgorithmEx(cudnnHandle_t handle,
                                        void *reserveSpace,
                                        size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNBackwardDataAlgorithmMaxCount(cudnnHandle_t handle, const cudnnRNNDescriptor_t rnnDesc, int *count)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6111,14 +6075,12 @@ cudnnFindRNNBackwardDataAlgorithmEx(cudnnHandle_t handle,
                                     void *reserveSpace,
                                     size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNBackwardWeightsAlgorithmMaxCount(cudnnHandle_t handle, const cudnnRNNDescriptor_t rnnDesc, int *count)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6143,7 +6105,6 @@ cudnnFindRNNBackwardWeightsAlgorithmEx(cudnnHandle_t handle,
                                        const void *reserveSpace,
                                        size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6164,7 +6125,6 @@ cudnnSetRNNDescriptor_v6(cudnnHandle_t handle,
                          cudnnRNNAlgo_t algo,
                          cudnnDataType_t mathPrec)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6178,7 +6138,6 @@ cudnnSetRNNDescriptor_v5(cudnnRNNDescriptor_t rnnDesc,
                          cudnnRNNMode_t mode,
                          cudnnDataType_t mathPrec)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 

--- a/cava/samples/onnxruntime/onnx_opt.cpp
+++ b/cava/samples/onnxruntime/onnx_opt.cpp
@@ -6140,7 +6140,6 @@ cudnnSetRNNDescriptor(cudnnHandle_t handle,
                       cudnnRNNAlgo_t algo,
                       cudnnDataType_t mathPrec)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6156,21 +6155,18 @@ cudnnGetRNNDescriptor(cudnnHandle_t handle,
                       cudnnRNNAlgo_t *algo,
                       cudnnDataType_t *mathPrec)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnSetRNNMatrixMathType(cudnnRNNDescriptor_t rnnDesc, cudnnMathType_t mType)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNMatrixMathType(cudnnRNNDescriptor_t rnnDesc, cudnnMathType_t *mType)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6182,7 +6178,6 @@ cudnnRNNSetClip(cudnnHandle_t handle,
                 double lclip,
                 double rclip)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6194,7 +6189,6 @@ cudnnRNNGetClip(cudnnHandle_t handle,
                 double *lclip,
                 double *rclip)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6204,7 +6198,6 @@ cudnnSetRNNProjectionLayers(cudnnHandle_t handle,
                             const int recProjSize,
                             const int outProjSize)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6214,7 +6207,6 @@ cudnnGetRNNProjectionLayers(cudnnHandle_t handle,
                             int *recProjSize,
                             int *outProjSize)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6225,21 +6217,18 @@ cudnnCreatePersistentRNNPlan(cudnnRNNDescriptor_t rnnDesc,
                              const cudnnDataType_t dataType,
                              cudnnPersistentRNNPlan_t *plan)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnDestroyPersistentRNNPlan(cudnnPersistentRNNPlan_t plan)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnSetPersistentRNNPlan(cudnnRNNDescriptor_t rnnDesc, cudnnPersistentRNNPlan_t plan)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6251,7 +6240,6 @@ cudnnGetRNNWorkspaceSize(cudnnHandle_t handle,
                          const cudnnTensorDescriptor_t *xDesc,
                          size_t *sizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6262,7 +6250,6 @@ cudnnGetRNNTrainingReserveSize(cudnnHandle_t handle,
                                const cudnnTensorDescriptor_t *xDesc,
                                size_t *sizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6273,7 +6260,6 @@ cudnnGetRNNParamsSize(cudnnHandle_t handle,
                       size_t *sizeInBytes,
                       cudnnDataType_t dataType)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6288,7 +6274,6 @@ cudnnGetRNNLinLayerMatrixParams(cudnnHandle_t handle,
                                 cudnnFilterDescriptor_t linLayerMatDesc,
                                 void **linLayerMat)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6303,7 +6288,6 @@ cudnnGetRNNLinLayerBiasParams(cudnnHandle_t handle,
                               cudnnFilterDescriptor_t linLayerBiasDesc,
                               void **linLayerBias)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6328,7 +6312,6 @@ cudnnRNNForwardInference(cudnnHandle_t handle,
                          void *workspace,
                          size_t workSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6355,7 +6338,6 @@ cudnnRNNForwardTraining(cudnnHandle_t handle,
                         void *reserveSpace,
                         size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6388,7 +6370,6 @@ cudnnRNNBackwardData(cudnnHandle_t handle,
                      void *reserveSpace,
                      size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6409,7 +6390,6 @@ cudnnRNNBackwardWeights(cudnnHandle_t handle,
                         const void *reserveSpace,
                         size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6418,28 +6398,24 @@ cudnnRNNBackwardWeights(cudnnHandle_t handle,
 cudnnStatus_t CUDNNWINAPI
 cudnnSetRNNPaddingMode(cudnnRNNDescriptor_t rnnDesc, cudnnRNNPaddingMode_t paddingMode)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNPaddingMode(cudnnRNNDescriptor_t rnnDesc, cudnnRNNPaddingMode_t *paddingMode)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnCreateRNNDataDescriptor(cudnnRNNDataDescriptor_t *rnnDataDesc)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnDestroyRNNDataDescriptor(cudnnRNNDataDescriptor_t rnnDataDesc)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6453,7 +6429,6 @@ cudnnSetRNNDataDescriptor(cudnnRNNDataDescriptor_t rnnDataDesc,
                           const int seqLengthArray[], /* length of each sequence in the batch */
                           void *paddingFill)          /* symbol for filling padding position in output */
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6468,7 +6443,6 @@ cudnnGetRNNDataDescriptor(cudnnRNNDataDescriptor_t rnnDataDesc,
                           int seqLengthArray[],
                           void *paddingFill)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6502,7 +6476,6 @@ cudnnRNNForwardTrainingEx(cudnnHandle_t handle,
                           void *reserveSpace,
                           size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6534,7 +6507,6 @@ cudnnRNNForwardInferenceEx(cudnnHandle_t handle,
                            void *workSpace,
                            size_t workSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6570,7 +6542,6 @@ cudnnRNNBackwardDataEx(cudnnHandle_t handle,
                        void *reserveSpace,
                        size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6590,7 +6561,6 @@ cudnnRNNBackwardWeightsEx(cudnnHandle_t handle,
                           void *reserveSpace,
                           size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6599,14 +6569,12 @@ cudnnRNNBackwardWeightsEx(cudnnHandle_t handle,
 cudnnStatus_t CUDNNWINAPI
 cudnnSetRNNAlgorithmDescriptor(cudnnHandle_t handle, cudnnRNNDescriptor_t rnnDesc, cudnnAlgorithmDescriptor_t algoDesc)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNForwardInferenceAlgorithmMaxCount(cudnnHandle_t handle, const cudnnRNNDescriptor_t rnnDesc, int *count)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6635,14 +6603,12 @@ cudnnFindRNNForwardInferenceAlgorithmEx(cudnnHandle_t handle,
                                         void *workspace,
                                         size_t workSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNForwardTrainingAlgorithmMaxCount(cudnnHandle_t handle, const cudnnRNNDescriptor_t rnnDesc, int *count)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6673,14 +6639,12 @@ cudnnFindRNNForwardTrainingAlgorithmEx(cudnnHandle_t handle,
                                        void *reserveSpace,
                                        size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNBackwardDataAlgorithmMaxCount(cudnnHandle_t handle, const cudnnRNNDescriptor_t rnnDesc, int *count)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6717,14 +6681,12 @@ cudnnFindRNNBackwardDataAlgorithmEx(cudnnHandle_t handle,
                                     void *reserveSpace,
                                     size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNBackwardWeightsAlgorithmMaxCount(cudnnHandle_t handle, const cudnnRNNDescriptor_t rnnDesc, int *count)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6749,7 +6711,6 @@ cudnnFindRNNBackwardWeightsAlgorithmEx(cudnnHandle_t handle,
                                        const void *reserveSpace,
                                        size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6770,7 +6731,6 @@ cudnnSetRNNDescriptor_v6(cudnnHandle_t handle,
                          cudnnRNNAlgo_t algo,
                          cudnnDataType_t mathPrec)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6784,7 +6744,6 @@ cudnnSetRNNDescriptor_v5(cudnnRNNDescriptor_t rnnDesc,
                          cudnnRNNMode_t mode,
                          cudnnDataType_t mathPrec)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 

--- a/cava/samples/pytorch/pt_dump.cpp
+++ b/cava/samples/pytorch/pt_dump.cpp
@@ -5591,7 +5591,6 @@ cudnnSetRNNDescriptor(cudnnHandle_t handle,
                       cudnnRNNAlgo_t algo,
                       cudnnDataType_t mathPrec)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5607,21 +5606,18 @@ cudnnGetRNNDescriptor(cudnnHandle_t handle,
                       cudnnRNNAlgo_t *algo,
                       cudnnDataType_t *mathPrec)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnSetRNNMatrixMathType(cudnnRNNDescriptor_t rnnDesc, cudnnMathType_t mType)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNMatrixMathType(cudnnRNNDescriptor_t rnnDesc, cudnnMathType_t *mType)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5633,7 +5629,6 @@ cudnnRNNSetClip(cudnnHandle_t handle,
                 double lclip,
                 double rclip)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5645,7 +5640,6 @@ cudnnRNNGetClip(cudnnHandle_t handle,
                 double *lclip,
                 double *rclip)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5655,7 +5649,6 @@ cudnnSetRNNProjectionLayers(cudnnHandle_t handle,
                             const int recProjSize,
                             const int outProjSize)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5665,7 +5658,6 @@ cudnnGetRNNProjectionLayers(cudnnHandle_t handle,
                             int *recProjSize,
                             int *outProjSize)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5676,21 +5668,18 @@ cudnnCreatePersistentRNNPlan(cudnnRNNDescriptor_t rnnDesc,
                              const cudnnDataType_t dataType,
                              cudnnPersistentRNNPlan_t *plan)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnDestroyPersistentRNNPlan(cudnnPersistentRNNPlan_t plan)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnSetPersistentRNNPlan(cudnnRNNDescriptor_t rnnDesc, cudnnPersistentRNNPlan_t plan)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5702,7 +5691,6 @@ cudnnGetRNNWorkspaceSize(cudnnHandle_t handle,
                          const cudnnTensorDescriptor_t *xDesc,
                          size_t *sizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5713,7 +5701,6 @@ cudnnGetRNNTrainingReserveSize(cudnnHandle_t handle,
                                const cudnnTensorDescriptor_t *xDesc,
                                size_t *sizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5724,7 +5711,6 @@ cudnnGetRNNParamsSize(cudnnHandle_t handle,
                       size_t *sizeInBytes,
                       cudnnDataType_t dataType)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5739,7 +5725,6 @@ cudnnGetRNNLinLayerMatrixParams(cudnnHandle_t handle,
                                 cudnnFilterDescriptor_t linLayerMatDesc,
                                 void **linLayerMat)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5754,7 +5739,6 @@ cudnnGetRNNLinLayerBiasParams(cudnnHandle_t handle,
                               cudnnFilterDescriptor_t linLayerBiasDesc,
                               void **linLayerBias)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5779,7 +5763,6 @@ cudnnRNNForwardInference(cudnnHandle_t handle,
                          void *workspace,
                          size_t workSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5806,7 +5789,6 @@ cudnnRNNForwardTraining(cudnnHandle_t handle,
                         void *reserveSpace,
                         size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5839,7 +5821,6 @@ cudnnRNNBackwardData(cudnnHandle_t handle,
                      void *reserveSpace,
                      size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5860,7 +5841,6 @@ cudnnRNNBackwardWeights(cudnnHandle_t handle,
                         const void *reserveSpace,
                         size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5869,28 +5849,24 @@ cudnnRNNBackwardWeights(cudnnHandle_t handle,
 cudnnStatus_t CUDNNWINAPI
 cudnnSetRNNPaddingMode(cudnnRNNDescriptor_t rnnDesc, cudnnRNNPaddingMode_t paddingMode)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNPaddingMode(cudnnRNNDescriptor_t rnnDesc, cudnnRNNPaddingMode_t *paddingMode)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnCreateRNNDataDescriptor(cudnnRNNDataDescriptor_t *rnnDataDesc)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnDestroyRNNDataDescriptor(cudnnRNNDataDescriptor_t rnnDataDesc)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5904,7 +5880,6 @@ cudnnSetRNNDataDescriptor(cudnnRNNDataDescriptor_t rnnDataDesc,
                           const int seqLengthArray[], /* length of each sequence in the batch */
                           void *paddingFill)          /* symbol for filling padding position in output */
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5919,7 +5894,6 @@ cudnnGetRNNDataDescriptor(cudnnRNNDataDescriptor_t rnnDataDesc,
                           int seqLengthArray[],
                           void *paddingFill)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5953,7 +5927,6 @@ cudnnRNNForwardTrainingEx(cudnnHandle_t handle,
                           void *reserveSpace,
                           size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5985,7 +5958,6 @@ cudnnRNNForwardInferenceEx(cudnnHandle_t handle,
                            void *workSpace,
                            size_t workSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6021,7 +5993,6 @@ cudnnRNNBackwardDataEx(cudnnHandle_t handle,
                        void *reserveSpace,
                        size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6041,7 +6012,6 @@ cudnnRNNBackwardWeightsEx(cudnnHandle_t handle,
                           void *reserveSpace,
                           size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6050,14 +6020,12 @@ cudnnRNNBackwardWeightsEx(cudnnHandle_t handle,
 cudnnStatus_t CUDNNWINAPI
 cudnnSetRNNAlgorithmDescriptor(cudnnHandle_t handle, cudnnRNNDescriptor_t rnnDesc, cudnnAlgorithmDescriptor_t algoDesc)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNForwardInferenceAlgorithmMaxCount(cudnnHandle_t handle, const cudnnRNNDescriptor_t rnnDesc, int *count)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6086,14 +6054,12 @@ cudnnFindRNNForwardInferenceAlgorithmEx(cudnnHandle_t handle,
                                         void *workspace,
                                         size_t workSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNForwardTrainingAlgorithmMaxCount(cudnnHandle_t handle, const cudnnRNNDescriptor_t rnnDesc, int *count)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6124,14 +6090,12 @@ cudnnFindRNNForwardTrainingAlgorithmEx(cudnnHandle_t handle,
                                        void *reserveSpace,
                                        size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNBackwardDataAlgorithmMaxCount(cudnnHandle_t handle, const cudnnRNNDescriptor_t rnnDesc, int *count)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6168,14 +6132,12 @@ cudnnFindRNNBackwardDataAlgorithmEx(cudnnHandle_t handle,
                                     void *reserveSpace,
                                     size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNBackwardWeightsAlgorithmMaxCount(cudnnHandle_t handle, const cudnnRNNDescriptor_t rnnDesc, int *count)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6200,7 +6162,6 @@ cudnnFindRNNBackwardWeightsAlgorithmEx(cudnnHandle_t handle,
                                        const void *reserveSpace,
                                        size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6221,7 +6182,6 @@ cudnnSetRNNDescriptor_v6(cudnnHandle_t handle,
                          cudnnRNNAlgo_t algo,
                          cudnnDataType_t mathPrec)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6235,7 +6195,6 @@ cudnnSetRNNDescriptor_v5(cudnnRNNDescriptor_t rnnDesc,
                          cudnnRNNMode_t mode,
                          cudnnDataType_t mathPrec)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 

--- a/cava/samples/pytorch/pt_opt.cpp
+++ b/cava/samples/pytorch/pt_opt.cpp
@@ -6161,7 +6161,6 @@ cudnnSetRNNDescriptor(cudnnHandle_t handle,
                       cudnnRNNAlgo_t algo,
                       cudnnDataType_t mathPrec)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6177,21 +6176,18 @@ cudnnGetRNNDescriptor(cudnnHandle_t handle,
                       cudnnRNNAlgo_t *algo,
                       cudnnDataType_t *mathPrec)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnSetRNNMatrixMathType(cudnnRNNDescriptor_t rnnDesc, cudnnMathType_t mType)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNMatrixMathType(cudnnRNNDescriptor_t rnnDesc, cudnnMathType_t *mType)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6203,7 +6199,6 @@ cudnnRNNSetClip(cudnnHandle_t handle,
                 double lclip,
                 double rclip)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6215,7 +6210,6 @@ cudnnRNNGetClip(cudnnHandle_t handle,
                 double *lclip,
                 double *rclip)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6225,7 +6219,6 @@ cudnnSetRNNProjectionLayers(cudnnHandle_t handle,
                             const int recProjSize,
                             const int outProjSize)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6235,7 +6228,6 @@ cudnnGetRNNProjectionLayers(cudnnHandle_t handle,
                             int *recProjSize,
                             int *outProjSize)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6246,21 +6238,18 @@ cudnnCreatePersistentRNNPlan(cudnnRNNDescriptor_t rnnDesc,
                              const cudnnDataType_t dataType,
                              cudnnPersistentRNNPlan_t *plan)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnDestroyPersistentRNNPlan(cudnnPersistentRNNPlan_t plan)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnSetPersistentRNNPlan(cudnnRNNDescriptor_t rnnDesc, cudnnPersistentRNNPlan_t plan)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6272,7 +6261,6 @@ cudnnGetRNNWorkspaceSize(cudnnHandle_t handle,
                          const cudnnTensorDescriptor_t *xDesc,
                          size_t *sizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6283,7 +6271,6 @@ cudnnGetRNNTrainingReserveSize(cudnnHandle_t handle,
                                const cudnnTensorDescriptor_t *xDesc,
                                size_t *sizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6294,7 +6281,6 @@ cudnnGetRNNParamsSize(cudnnHandle_t handle,
                       size_t *sizeInBytes,
                       cudnnDataType_t dataType)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6309,7 +6295,6 @@ cudnnGetRNNLinLayerMatrixParams(cudnnHandle_t handle,
                                 cudnnFilterDescriptor_t linLayerMatDesc,
                                 void **linLayerMat)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6324,7 +6309,6 @@ cudnnGetRNNLinLayerBiasParams(cudnnHandle_t handle,
                               cudnnFilterDescriptor_t linLayerBiasDesc,
                               void **linLayerBias)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6349,7 +6333,6 @@ cudnnRNNForwardInference(cudnnHandle_t handle,
                          void *workspace,
                          size_t workSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6376,7 +6359,6 @@ cudnnRNNForwardTraining(cudnnHandle_t handle,
                         void *reserveSpace,
                         size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6409,7 +6391,6 @@ cudnnRNNBackwardData(cudnnHandle_t handle,
                      void *reserveSpace,
                      size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6430,7 +6411,6 @@ cudnnRNNBackwardWeights(cudnnHandle_t handle,
                         const void *reserveSpace,
                         size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6439,28 +6419,24 @@ cudnnRNNBackwardWeights(cudnnHandle_t handle,
 cudnnStatus_t CUDNNWINAPI
 cudnnSetRNNPaddingMode(cudnnRNNDescriptor_t rnnDesc, cudnnRNNPaddingMode_t paddingMode)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNPaddingMode(cudnnRNNDescriptor_t rnnDesc, cudnnRNNPaddingMode_t *paddingMode)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnCreateRNNDataDescriptor(cudnnRNNDataDescriptor_t *rnnDataDesc)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnDestroyRNNDataDescriptor(cudnnRNNDataDescriptor_t rnnDataDesc)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6474,7 +6450,6 @@ cudnnSetRNNDataDescriptor(cudnnRNNDataDescriptor_t rnnDataDesc,
                           const int seqLengthArray[], /* length of each sequence in the batch */
                           void *paddingFill)          /* symbol for filling padding position in output */
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6489,7 +6464,6 @@ cudnnGetRNNDataDescriptor(cudnnRNNDataDescriptor_t rnnDataDesc,
                           int seqLengthArray[],
                           void *paddingFill)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6523,7 +6497,6 @@ cudnnRNNForwardTrainingEx(cudnnHandle_t handle,
                           void *reserveSpace,
                           size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6555,7 +6528,6 @@ cudnnRNNForwardInferenceEx(cudnnHandle_t handle,
                            void *workSpace,
                            size_t workSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6591,7 +6563,6 @@ cudnnRNNBackwardDataEx(cudnnHandle_t handle,
                        void *reserveSpace,
                        size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6611,7 +6582,6 @@ cudnnRNNBackwardWeightsEx(cudnnHandle_t handle,
                           void *reserveSpace,
                           size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6620,14 +6590,12 @@ cudnnRNNBackwardWeightsEx(cudnnHandle_t handle,
 cudnnStatus_t CUDNNWINAPI
 cudnnSetRNNAlgorithmDescriptor(cudnnHandle_t handle, cudnnRNNDescriptor_t rnnDesc, cudnnAlgorithmDescriptor_t algoDesc)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNForwardInferenceAlgorithmMaxCount(cudnnHandle_t handle, const cudnnRNNDescriptor_t rnnDesc, int *count)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6656,14 +6624,12 @@ cudnnFindRNNForwardInferenceAlgorithmEx(cudnnHandle_t handle,
                                         void *workspace,
                                         size_t workSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNForwardTrainingAlgorithmMaxCount(cudnnHandle_t handle, const cudnnRNNDescriptor_t rnnDesc, int *count)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6694,14 +6660,12 @@ cudnnFindRNNForwardTrainingAlgorithmEx(cudnnHandle_t handle,
                                        void *reserveSpace,
                                        size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNBackwardDataAlgorithmMaxCount(cudnnHandle_t handle, const cudnnRNNDescriptor_t rnnDesc, int *count)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6738,14 +6702,12 @@ cudnnFindRNNBackwardDataAlgorithmEx(cudnnHandle_t handle,
                                     void *reserveSpace,
                                     size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNBackwardWeightsAlgorithmMaxCount(cudnnHandle_t handle, const cudnnRNNDescriptor_t rnnDesc, int *count)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6770,7 +6732,6 @@ cudnnFindRNNBackwardWeightsAlgorithmEx(cudnnHandle_t handle,
                                        const void *reserveSpace,
                                        size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6791,7 +6752,6 @@ cudnnSetRNNDescriptor_v6(cudnnHandle_t handle,
                          cudnnRNNAlgo_t algo,
                          cudnnDataType_t mathPrec)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6805,7 +6765,6 @@ cudnnSetRNNDescriptor_v5(cudnnRNNDescriptor_t rnnDesc,
                          cudnnRNNMode_t mode,
                          cudnnDataType_t mathPrec)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 

--- a/cava/samples/tensorflow/tf_dump.cpp
+++ b/cava/samples/tensorflow/tf_dump.cpp
@@ -5574,7 +5574,6 @@ cudnnSetRNNDescriptor(cudnnHandle_t handle,
                       cudnnRNNAlgo_t algo,
                       cudnnDataType_t mathPrec)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5590,21 +5589,18 @@ cudnnGetRNNDescriptor(cudnnHandle_t handle,
                       cudnnRNNAlgo_t *algo,
                       cudnnDataType_t *mathPrec)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnSetRNNMatrixMathType(cudnnRNNDescriptor_t rnnDesc, cudnnMathType_t mType)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNMatrixMathType(cudnnRNNDescriptor_t rnnDesc, cudnnMathType_t *mType)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5616,7 +5612,6 @@ cudnnRNNSetClip(cudnnHandle_t handle,
                 double lclip,
                 double rclip)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5628,7 +5623,6 @@ cudnnRNNGetClip(cudnnHandle_t handle,
                 double *lclip,
                 double *rclip)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5638,7 +5632,6 @@ cudnnSetRNNProjectionLayers(cudnnHandle_t handle,
                             const int recProjSize,
                             const int outProjSize)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5648,7 +5641,6 @@ cudnnGetRNNProjectionLayers(cudnnHandle_t handle,
                             int *recProjSize,
                             int *outProjSize)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5659,21 +5651,18 @@ cudnnCreatePersistentRNNPlan(cudnnRNNDescriptor_t rnnDesc,
                              const cudnnDataType_t dataType,
                              cudnnPersistentRNNPlan_t *plan)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnDestroyPersistentRNNPlan(cudnnPersistentRNNPlan_t plan)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnSetPersistentRNNPlan(cudnnRNNDescriptor_t rnnDesc, cudnnPersistentRNNPlan_t plan)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5685,7 +5674,6 @@ cudnnGetRNNWorkspaceSize(cudnnHandle_t handle,
                          const cudnnTensorDescriptor_t *xDesc,
                          size_t *sizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5696,7 +5684,6 @@ cudnnGetRNNTrainingReserveSize(cudnnHandle_t handle,
                                const cudnnTensorDescriptor_t *xDesc,
                                size_t *sizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5707,7 +5694,6 @@ cudnnGetRNNParamsSize(cudnnHandle_t handle,
                       size_t *sizeInBytes,
                       cudnnDataType_t dataType)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5722,7 +5708,6 @@ cudnnGetRNNLinLayerMatrixParams(cudnnHandle_t handle,
                                 cudnnFilterDescriptor_t linLayerMatDesc,
                                 void **linLayerMat)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5737,7 +5722,6 @@ cudnnGetRNNLinLayerBiasParams(cudnnHandle_t handle,
                               cudnnFilterDescriptor_t linLayerBiasDesc,
                               void **linLayerBias)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5762,7 +5746,6 @@ cudnnRNNForwardInference(cudnnHandle_t handle,
                          void *workspace,
                          size_t workSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5789,7 +5772,6 @@ cudnnRNNForwardTraining(cudnnHandle_t handle,
                         void *reserveSpace,
                         size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5822,7 +5804,6 @@ cudnnRNNBackwardData(cudnnHandle_t handle,
                      void *reserveSpace,
                      size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5843,7 +5824,6 @@ cudnnRNNBackwardWeights(cudnnHandle_t handle,
                         const void *reserveSpace,
                         size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5852,14 +5832,12 @@ cudnnRNNBackwardWeights(cudnnHandle_t handle,
 cudnnStatus_t CUDNNWINAPI
 cudnnSetRNNPaddingMode(cudnnRNNDescriptor_t rnnDesc, cudnnRNNPaddingMode_t paddingMode)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNPaddingMode(cudnnRNNDescriptor_t rnnDesc, cudnnRNNPaddingMode_t *paddingMode)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5899,7 +5877,6 @@ cudnnGetRNNDataDescriptor(cudnnRNNDataDescriptor_t rnnDataDesc,
                           int seqLengthArray[],
                           void *paddingFill)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -5964,7 +5941,6 @@ cudnnRNNForwardInferenceEx(cudnnHandle_t handle,
                            void *workSpace,
                            size_t workSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6027,14 +6003,12 @@ cudnnRNNBackwardWeightsEx(cudnnHandle_t handle,
 cudnnStatus_t CUDNNWINAPI
 cudnnSetRNNAlgorithmDescriptor(cudnnHandle_t handle, cudnnRNNDescriptor_t rnnDesc, cudnnAlgorithmDescriptor_t algoDesc)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNForwardInferenceAlgorithmMaxCount(cudnnHandle_t handle, const cudnnRNNDescriptor_t rnnDesc, int *count)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6063,14 +6037,12 @@ cudnnFindRNNForwardInferenceAlgorithmEx(cudnnHandle_t handle,
                                         void *workspace,
                                         size_t workSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNForwardTrainingAlgorithmMaxCount(cudnnHandle_t handle, const cudnnRNNDescriptor_t rnnDesc, int *count)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6101,14 +6073,12 @@ cudnnFindRNNForwardTrainingAlgorithmEx(cudnnHandle_t handle,
                                        void *reserveSpace,
                                        size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNBackwardDataAlgorithmMaxCount(cudnnHandle_t handle, const cudnnRNNDescriptor_t rnnDesc, int *count)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6145,14 +6115,12 @@ cudnnFindRNNBackwardDataAlgorithmEx(cudnnHandle_t handle,
                                     void *reserveSpace,
                                     size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNBackwardWeightsAlgorithmMaxCount(cudnnHandle_t handle, const cudnnRNNDescriptor_t rnnDesc, int *count)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6177,7 +6145,6 @@ cudnnFindRNNBackwardWeightsAlgorithmEx(cudnnHandle_t handle,
                                        const void *reserveSpace,
                                        size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6198,7 +6165,6 @@ cudnnSetRNNDescriptor_v6(cudnnHandle_t handle,
                          cudnnRNNAlgo_t algo,
                          cudnnDataType_t mathPrec)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6212,7 +6178,6 @@ cudnnSetRNNDescriptor_v5(cudnnRNNDescriptor_t rnnDesc,
                          cudnnRNNMode_t mode,
                          cudnnDataType_t mathPrec)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 

--- a/cava/samples/tensorflow/tf_opt.cpp
+++ b/cava/samples/tensorflow/tf_opt.cpp
@@ -6162,7 +6162,6 @@ cudnnSetRNNDescriptor(cudnnHandle_t handle,
                       cudnnRNNAlgo_t algo,
                       cudnnDataType_t mathPrec)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6178,21 +6177,18 @@ cudnnGetRNNDescriptor(cudnnHandle_t handle,
                       cudnnRNNAlgo_t *algo,
                       cudnnDataType_t *mathPrec)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnSetRNNMatrixMathType(cudnnRNNDescriptor_t rnnDesc, cudnnMathType_t mType)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNMatrixMathType(cudnnRNNDescriptor_t rnnDesc, cudnnMathType_t *mType)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6204,7 +6200,6 @@ cudnnRNNSetClip(cudnnHandle_t handle,
                 double lclip,
                 double rclip)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6216,7 +6211,6 @@ cudnnRNNGetClip(cudnnHandle_t handle,
                 double *lclip,
                 double *rclip)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6226,7 +6220,6 @@ cudnnSetRNNProjectionLayers(cudnnHandle_t handle,
                             const int recProjSize,
                             const int outProjSize)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6236,7 +6229,6 @@ cudnnGetRNNProjectionLayers(cudnnHandle_t handle,
                             int *recProjSize,
                             int *outProjSize)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6247,21 +6239,18 @@ cudnnCreatePersistentRNNPlan(cudnnRNNDescriptor_t rnnDesc,
                              const cudnnDataType_t dataType,
                              cudnnPersistentRNNPlan_t *plan)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnDestroyPersistentRNNPlan(cudnnPersistentRNNPlan_t plan)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnSetPersistentRNNPlan(cudnnRNNDescriptor_t rnnDesc, cudnnPersistentRNNPlan_t plan)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6273,7 +6262,6 @@ cudnnGetRNNWorkspaceSize(cudnnHandle_t handle,
                          const cudnnTensorDescriptor_t *xDesc,
                          size_t *sizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6284,7 +6272,6 @@ cudnnGetRNNTrainingReserveSize(cudnnHandle_t handle,
                                const cudnnTensorDescriptor_t *xDesc,
                                size_t *sizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6295,7 +6282,6 @@ cudnnGetRNNParamsSize(cudnnHandle_t handle,
                       size_t *sizeInBytes,
                       cudnnDataType_t dataType)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6310,7 +6296,6 @@ cudnnGetRNNLinLayerMatrixParams(cudnnHandle_t handle,
                                 cudnnFilterDescriptor_t linLayerMatDesc,
                                 void **linLayerMat)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6325,7 +6310,6 @@ cudnnGetRNNLinLayerBiasParams(cudnnHandle_t handle,
                               cudnnFilterDescriptor_t linLayerBiasDesc,
                               void **linLayerBias)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6350,7 +6334,6 @@ cudnnRNNForwardInference(cudnnHandle_t handle,
                          void *workspace,
                          size_t workSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6377,7 +6360,6 @@ cudnnRNNForwardTraining(cudnnHandle_t handle,
                         void *reserveSpace,
                         size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6410,7 +6392,6 @@ cudnnRNNBackwardData(cudnnHandle_t handle,
                      void *reserveSpace,
                      size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6431,7 +6412,6 @@ cudnnRNNBackwardWeights(cudnnHandle_t handle,
                         const void *reserveSpace,
                         size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6440,28 +6420,24 @@ cudnnRNNBackwardWeights(cudnnHandle_t handle,
 cudnnStatus_t CUDNNWINAPI
 cudnnSetRNNPaddingMode(cudnnRNNDescriptor_t rnnDesc, cudnnRNNPaddingMode_t paddingMode)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNPaddingMode(cudnnRNNDescriptor_t rnnDesc, cudnnRNNPaddingMode_t *paddingMode)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnCreateRNNDataDescriptor(cudnnRNNDataDescriptor_t *rnnDataDesc)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnDestroyRNNDataDescriptor(cudnnRNNDataDescriptor_t rnnDataDesc)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6475,7 +6451,6 @@ cudnnSetRNNDataDescriptor(cudnnRNNDataDescriptor_t rnnDataDesc,
                           const int seqLengthArray[], /* length of each sequence in the batch */
                           void *paddingFill)          /* symbol for filling padding position in output */
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6490,7 +6465,6 @@ cudnnGetRNNDataDescriptor(cudnnRNNDataDescriptor_t rnnDataDesc,
                           int seqLengthArray[],
                           void *paddingFill)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6524,7 +6498,6 @@ cudnnRNNForwardTrainingEx(cudnnHandle_t handle,
                           void *reserveSpace,
                           size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6556,7 +6529,6 @@ cudnnRNNForwardInferenceEx(cudnnHandle_t handle,
                            void *workSpace,
                            size_t workSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6592,7 +6564,6 @@ cudnnRNNBackwardDataEx(cudnnHandle_t handle,
                        void *reserveSpace,
                        size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6612,7 +6583,6 @@ cudnnRNNBackwardWeightsEx(cudnnHandle_t handle,
                           void *reserveSpace,
                           size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6621,14 +6591,12 @@ cudnnRNNBackwardWeightsEx(cudnnHandle_t handle,
 cudnnStatus_t CUDNNWINAPI
 cudnnSetRNNAlgorithmDescriptor(cudnnHandle_t handle, cudnnRNNDescriptor_t rnnDesc, cudnnAlgorithmDescriptor_t algoDesc)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNForwardInferenceAlgorithmMaxCount(cudnnHandle_t handle, const cudnnRNNDescriptor_t rnnDesc, int *count)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6657,14 +6625,12 @@ cudnnFindRNNForwardInferenceAlgorithmEx(cudnnHandle_t handle,
                                         void *workspace,
                                         size_t workSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNForwardTrainingAlgorithmMaxCount(cudnnHandle_t handle, const cudnnRNNDescriptor_t rnnDesc, int *count)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6695,14 +6661,12 @@ cudnnFindRNNForwardTrainingAlgorithmEx(cudnnHandle_t handle,
                                        void *reserveSpace,
                                        size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNBackwardDataAlgorithmMaxCount(cudnnHandle_t handle, const cudnnRNNDescriptor_t rnnDesc, int *count)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6739,14 +6703,12 @@ cudnnFindRNNBackwardDataAlgorithmEx(cudnnHandle_t handle,
                                     void *reserveSpace,
                                     size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
 cudnnStatus_t CUDNNWINAPI
 cudnnGetRNNBackwardWeightsAlgorithmMaxCount(cudnnHandle_t handle, const cudnnRNNDescriptor_t rnnDesc, int *count)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6771,7 +6733,6 @@ cudnnFindRNNBackwardWeightsAlgorithmEx(cudnnHandle_t handle,
                                        const void *reserveSpace,
                                        size_t reserveSpaceSizeInBytes)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6792,7 +6753,6 @@ cudnnSetRNNDescriptor_v6(cudnnHandle_t handle,
                          cudnnRNNAlgo_t algo,
                          cudnnDataType_t mathPrec)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 
@@ -6806,7 +6766,6 @@ cudnnSetRNNDescriptor_v5(cudnnRNNDescriptor_t rnnDesc,
                          cudnnRNNMode_t mode,
                          cudnnDataType_t mathPrec)
 {
-    fprintf(stderr, "%s is not implemented\n", __PRETTY_FUNCTION__);
     ava_unsupported;
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Cava automatically generates assertions with prints for the function name for APIs with the `ava_unsupported` annotation. There is no need to add prints to them.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update (this change is mainly a documentation update)

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
- [x] My code passes format and lint checks.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have tested my code with a reasonable workload.
- [ ] My code **may break** some other features.
