### PR TITLE
Disable pylint W1202 fstring interpolation in .flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -14,6 +14,7 @@ ignore =
   W503
   W504
   W605
+  W1202
   I
   N
 avoid-escape = no


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Old version of `black` seems to read .flake8 which didn't disable W1202.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Document update (this change is mainly a documentation update)

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
- [x] My code passes format and lint checks.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have tested my code with a reasonable workload.
- [ ] My code **may break** some other features.
